### PR TITLE
feature: 공통 BaseTimeEntity 도입을 통한 생성·수정 시각 관리 표준화

### DIFF
--- a/src/main/java/com/thunder11/scuad/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/thunder11/scuad/common/entity/BaseTimeEntity.java
@@ -1,0 +1,27 @@
+package com.thunder11.scuad.common.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
**1. 작업 내용**
- 생성 시각(created_at)과 수정 시각(updated_at)을 공통으로 관리하기 위한 BaseTimeEntity 추상 클래스 추가
- @MappedSuperclass를 사용해 테이블은 생성하지 않고, 상속받는 엔티티에 공통 컬럼을 제공하도록 설계

- Spring Data JPA Auditing(@CreatedDate, @LastModifiedDate)을 적용하여 엔티티 생성·수정 시 타임스탬프가 자동으로 설정되도록 구현

**2. 설계 의도**

생성 시각과 수정 시각은 대부분의 엔티티에서 반복적으로 사용되는 공통 속성이기 때문에 공통 베이스 엔티티로 분리했습니다.
BaseTimeEntity를 상속받는 방식으로 모든 엔티티에 동일한 시간 관리 규칙을 적용하여 코드 중복을 줄이고 일관성을 확보하고자 했습니다.
또한 타임스탬프를 DB 기본값이 아닌 JPA Auditing을 통해 애플리케이션 레벨에서 관리함으로써 생성·수정 시점이 코드 흐름상 명확히 드러나고 테스트 및 디버깅이 용이하도록 설계했습니다.