### PR TITLE
feat(auth): JWT 인증 필터 구현

### DIFF
--- a/src/main/java/com/thunder11/scuad/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/thunder11/scuad/auth/security/JwtAuthenticationFilter.java
@@ -1,0 +1,97 @@
+package com.thunder11.scuad.auth.security;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.thunder11.scuad.auth.domain.Role;
+import com.thunder11.scuad.auth.util.JwtProvider;
+import com.thunder11.scuad.common.exception.ApiException;
+
+// JWT 인증 필터
+// Authorization 헤더에서 JWT를 추출하고 검증하여 SecurityContext에 인증 정보 저장
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        try {
+            // 1. Authorization 헤더에서 JWT 추출
+            String token = extractTokenFromRequest(request);
+
+            // 2. 토큰이 있으면 검증 및 인증 처리
+            if (token != null) {
+                // 토큰 검증
+                jwtProvider.validateToken(token);
+
+                // 토큰에서 사용자 정보 추출
+                Long userId = jwtProvider.getUserIdFromToken(token);
+                String roleStr = jwtProvider.getRoleFromToken(token);
+                Role role = Role.valueOf(roleStr);
+
+                // UserPrincipal 생성
+                UserPrincipal userPrincipal = UserPrincipal.of(userId, role);
+
+                // Authentication 객체 생성
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userPrincipal,  // principal
+                                null,           // credentials (JWT는 불필요)
+                                null            // authorities (Role은 Principal에 포함)
+                        );
+
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                // SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.debug("JWT 인증 성공: userId={}, role={}", userId, role);
+            }
+
+        } catch (ApiException e) {
+            // JWT 검증 실패 (만료, 위조 등)
+            log.warn("JWT 검증 실패: {}", e.getMessage());
+            // SecurityContext를 비워서 인증 실패 처리
+            SecurityContextHolder.clearContext();
+        } catch (Exception e) {
+            log.error("JWT 필터 처리 중 오류 발생", e);
+            SecurityContextHolder.clearContext();
+        }
+
+        // 다음 필터로 진행
+        filterChain.doFilter(request, response);
+    }
+
+    // Authorization 헤더에서 Bearer 토큰 추출
+    private String extractTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7); // "Bearer " 제거
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/thunder11/scuad/auth/security/UserPrincipal.java
+++ b/src/main/java/com/thunder11/scuad/auth/security/UserPrincipal.java
@@ -1,0 +1,20 @@
+package com.thunder11.scuad.auth.security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import com.thunder11.scuad.auth.domain.Role;
+
+// 인증된 사용자 정보를 담는 객체
+// SecurityContext에 저장되어 컨트롤러에서 사용
+@Getter
+@RequiredArgsConstructor
+public class UserPrincipal {
+
+    private final Long userId;
+    private final Role role;
+
+    public static UserPrincipal of(Long userId, Role role) {
+        return new UserPrincipal(userId, role);
+    }
+}

--- a/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
+++ b/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
@@ -7,12 +7,20 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+import com.thunder11.scuad.auth.security.JwtAuthenticationFilter;
 
 // Spring Security 설정
-// OAuth 로그인 URL은 퍼블릭 허용, JWT 기반 인증 사용
+// JWT 기반 인증, OAuth 로그인 URL은 퍼블릭 허용
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -40,7 +48,10 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
 
                 // HTTP Basic 인증 비활성화
-                .httpBasic(AbstractHttpConfigurer::disable);
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                // JWT 인증 필터 추가 (UsernamePasswordAuthenticationFilter 앞에 배치)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
## 작업 내용

### **JWT 인증 필터 구현**

- **UserPrincipal 클래스 생성**
  - 인증된 사용자 정보를 담는 객체
  - userId와 role을 포함
  - SecurityContext에 저장되어 컨트롤러에서 @AuthenticationPrincipal로 접근 가능

- **JwtAuthenticationFilter 구현**
  - OncePerRequestFilter를 상속하여 요청당 한 번만 실행되도록 보장
  - Authorization 헤더에서 "Bearer {token}" 형식의 JWT 추출
  - JwtProvider를 통해 토큰 검증 (서명, 만료 시간)
  - 토큰에서 userId와 role 추출
  - UsernamePasswordAuthenticationToken 생성하여 SecurityContext에 저장
  - 검증 실패 시 SecurityContext를 비워 인증 실패 처리

- **SecurityConfig 수정**
  - JwtAuthenticationFilter를 Spring Security 필터 체인에 등록
  - UsernamePasswordAuthenticationFilter 앞에 배치하여 JWT 검증을 먼저 수행
  - 기존 설정 유지 (CSRF 비활성화, Stateless 세션, URL별 권한 설정)

---

## 설계 의도

### **OncePerRequestFilter 채택**

`JwtAuthenticationFilter`는 `OncePerRequestFilter`를 상속하여 구현했습니다. Spring MVC에서는 하나의 HTTP 요청이 여러 서블릿을 거치거나 포워딩될 때 동일한 필터가 여러 번 실행될 수 있습니다. 특히 에러 핸들링이나 내부 포워딩 시 필터 체인이 재실행되면서 중복 처리가 발생할 수 있습니다.

`OncePerRequestFilter`는 요청당 단 한 번만 실행되도록 보장하므로:
- JWT 검증이 중복으로 수행되지 않아 성능 낭비 방지
- SecurityContext가 여러 번 덮어씌워지는 문제 방지
- 로그가 중복으로 출력되지 않아 디버깅 용이

이는 인증 필터의 표준 구현 패턴으로, Spring Security의 공식 문서에서도 권장하는 방식입니다.

### **Bearer 토큰 형식 준수**

Authorization 헤더에서 토큰을 추출할 때 "Bearer " 접두사를 확인하고 제거하도록 구현했습니다. 이는 RFC 6750(OAuth 2.0 Bearer Token Usage) 표준을 따른 것으로:
- `Authorization: Bearer {token}` 형식은 HTTP 인증의 표준 방식
- REST API에서 가장 널리 사용되는 토큰 전달 방식
- 다른 인증 방식(Basic, Digest 등)과 명확히 구분 가능
- 프론트엔드, 모바일 등 다양한 클라이언트에서 일관되게 사용 가능

`StringUtils.hasText()`를 사용하여 null, 빈 문자열, 공백만 있는 경우를 모두 처리했으며, `startsWith("Bearer ")`로 형식을 검증하여 잘못된 헤더 형식을 사전에 차단했습니다.

### **UserPrincipal을 통한 정보 전달**

인증된 사용자 정보를 전달하기 위해 단순 Long(userId)이나 Map이 아닌 `UserPrincipal` 클래스를 별도로 생성했습니다. 이는 다음과 같은 이점을 제공합니다:

**타입 안정성**: 컨트롤러에서 `@AuthenticationPrincipal UserPrincipal`로 명시적으로 타입을 지정하여 컴파일 타임에 타입 오류를 검출할 수 있습니다. Long이나 Object를 사용하면 런타임 캐스팅 오류가 발생할 수 있습니다.

**확장성**: 현재는 userId와 role만 포함하지만, 향후 nickname, email 등 추가 정보가 필요하면 UserPrincipal에 필드를 추가하기만 하면 됩니다. 컨트롤러 코드는 수정할 필요가 없습니다.

**가독성**: `userPrincipal.getUserId()`는 `(Long) authentication.getPrincipal()`보다 의도가 명확하고 코드 리뷰 시 이해하기 쉽습니다.

**테스트 용이성**: Mock 객체 생성이 간단하며, 테스트 코드에서 `UserPrincipal.of(1L, Role.USER)`로 쉽게 생성할 수 있습니다.

### **필터 배치 위치 선정**

`JwtAuthenticationFilter`를 `UsernamePasswordAuthenticationFilter` 앞에 배치했습니다. Spring Security의 기본 필터 체인에서 `UsernamePasswordAuthenticationFilter`는 폼 로그인 처리를 담당하는데, 우리 프로젝트는 JWT 기반 인증을 사용하므로 이 필터보다 먼저 실행되어야 합니다.

필터 순서가 중요한 이유는:
- 앞쪽에 배치할수록 인증이 빨리 처리되어 불필요한 필터 실행 방지
- `UsernamePasswordAuthenticationFilter` 이후에 배치하면 폼 로그인 처리 로직이 먼저 실행되어 혼란 초래
- Spring Security의 표준 필터 순서를 따라 일관성 유지

`addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)` 메서드를 사용하여 명시적으로 순서를 지정했으며, 이는 Spring Security의 권장 방식입니다.
