### PR TITLE
Feature/chatroom info join

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -95,4 +95,22 @@ public class ChatRoomController {
                 response
         );
     }
+
+    // 채팅방 입장
+    @PostMapping("/chat-rooms/{chatRoomId}/members")
+    public ApiResponse<Void> joinChatRoom(
+            @PathVariable Long chatRoomId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        log.info("POST /api/v1/chat-rooms/{}/members - userId={}",
+                chatRoomId, userPrincipal.getUserId());
+
+        chatRoomService.joinChatRoom(chatRoomId, userPrincipal.getUserId());
+
+        return ApiResponse.of(
+                HttpStatus.OK.value(),
+                "CHAT_ROOM_JOINED",
+                "채팅방 입장 완료"
+        );
+    }
 }

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.thunder11.scuad.chat.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.thunder11.scuad.chat.domain.type.RoomStatus;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -255,5 +256,67 @@ public class ChatRoomService {
         log.info("채팅방 상세 조회 완료: chatRoomId={}", chatRoomId);
 
         return response;
+    }
+
+    // 채팅방 입장
+    @Transactional
+    public void joinChatRoom(Long chatRoomId, Long userId) {
+        log.info("채팅방 입장 시작: chatRoomId={}, userId={}", chatRoomId, userId);
+
+        // 1. 채팅방 존재 확인
+        ChatRoom chatRoom = chatRoomRepository.findByIdNotDeleted(chatRoomId)
+                .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 2. 채팅방 상태 확인 (ACTIVE만 입장 가능)
+        if (chatRoom.getStatus() != RoomStatus.ACTIVE) {
+            throw new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND);
+        }
+
+        // 3. 이미 참여 중인지 확인
+        if (chatRoomMemberRepository.findByChatRoomIdAndUserIdAndKickedAtIsNull(chatRoomId, userId).isPresent()) {
+            log.warn("이미 참여 중인 채팅방: chatRoomId={}, userId={}", chatRoomId, userId);
+            throw new ApiException(ErrorCode.CHAT_ROOM_ALREADY_JOINED);
+        }
+
+        // 4. 정원 확인
+        long currentParticipants = chatRoomMemberRepository.countByChatRoomIdAndKickedAtIsNull(chatRoomId);
+        if (currentParticipants >= chatRoom.getMaxParticipants()) {
+            log.warn("정원 초과: chatRoomId={}, current={}, max={}",
+                    chatRoomId, currentParticipants, chatRoom.getMaxParticipants());
+            throw new ApiException(ErrorCode.CHAT_ROOM_FULL);
+        }
+
+        // TODO: 5. jobApplicationId 조회 (JobPosting 연동 필요)
+        Long jobApplicationId = 1L; // 임시값
+
+        // TODO: 6. 강퇴 여부 확인
+        // ChatRoomMember를 찾을 때 kicked_at이 NULL인 것만 찾으므로,
+        // 만약 강퇴된 기록이 있으면 별도 체크 필요
+        // (현재는 kicked_at이 있으면 재입장 차단하는 로직 필요)
+
+        // TODO: 7. 같은 공고 다른 방 참여 확인
+        // Optional<ChatRoomMember> otherRoom = chatRoomMemberRepository
+        //     .findByJobApplicationIdAndNotKicked(jobApplicationId);
+        // if (otherRoom.isPresent() && !otherRoom.get().getChatRoomId().equals(chatRoomId)) {
+        //     throw new ApiException(ErrorCode.CHAT_ROOM_ALREADY_JOINED_OTHER);
+        // }
+
+        // TODO: 8. 서류 제출 확인 (JobPosting 연동 필요)
+
+        // TODO: 9. 커트라인 점수 확인 (JobPosting 연동 필요)
+
+        // 10. 멤버 등록
+        ChatRoomMember member = ChatRoomMember.builder()
+                .chatRoomId(chatRoomId)
+                .userId(userId)
+                .jobApplicationId(jobApplicationId)
+                .role(MemberRole.MEMBER)
+                .build();
+
+        chatRoomMemberRepository.save(member);
+        log.info("채팅방 입장 완료: chatRoomId={}, userId={}, chatRoomMemberId={}",
+                chatRoomId, userId, member.getChatRoomMemberId());
+
+        // TODO: 11. 시스템 메시지 생성 ("OO님이 입장했습니다")
     }
 }


### PR DESCRIPTION
## 작업 내용

### **채팅방 상세 정보 조회 API 구현**

- **ChatRoomService에 상세 조회 메서드 추가**
  - `getChatRoomDetail()`: 채팅방 ID로 상세 정보 조회
  - 채팅방 존재 확인 및 Soft Delete 필터링
  - 현재 인원 수(memberCount) 계산
  - ChatRoom 엔티티를 ChatRoomDetailResponse로 변환
  - 공고 요약 정보(JobMasterSummary) 포함

- **ChatRoomController에 엔드포인트 추가**
  - `GET /api/v1/chat-rooms/{chatRoomId}`: 채팅방 상세 조회
  - JWT 인증을 통한 사용자 식별
  - 채팅방 기본 정보 + 공고 정보 + 멤버 수 반환

### **채팅방 입장 API 구현**

- **ChatRoomService에 입장 메서드 추가**
  - `joinChatRoom()`: 채팅방 입장 처리
  - 채팅방 존재 및 상태(ACTIVE) 확인
  - 중복 참여 방지 (이미 참여 중인 사용자 체크)
  - 정원 확인 (maxParticipants 초과 방지)
  - ChatRoomMember 생성 및 저장 (MEMBER 역할)
  - 트랜잭션으로 원자성 보장

- **ChatRoomController에 엔드포인트 추가**
  - `POST /api/v1/chat-rooms/{chatRoomId}/members`: 채팅방 입장
  - JWT 인증을 통한 사용자 식별
  - 입장 성공 시 200 OK 응답

### **입장 시 검증 로직**

- 채팅방 존재 여부 확인 (`findByIdNotDeleted`)
- 채팅방 상태 확인 (ACTIVE만 입장 가능)
- 중복 참여 방지 (`findByChatRoomIdAndUserIdAndKickedAtIsNull`)
- 정원 초과 방지 (`countByChatRoomIdAndKickedAtIsNull`)
- 멤버 등록 (chatRoomId, userId, jobApplicationId, role=MEMBER)

---

## 설계 의도

### **채팅방 상세 조회 API 설계**

채팅방 상세 정보 조회는 채팅방 목록 조회보다 더 상세한 정보를 제공합니다. 목록 조회가 여러 채팅방의 요약 정보를 보여주는 것과 달리, 상세 조회는 사용자가 특정 채팅방에 관심을 가지고 입장을 고려할 때 필요한 모든 정보를 제공합니다.

**목록 조회(Summary)와 상세 조회(Detail)의 차이**:
- 목록: 방장 닉네임, 입장 가능 여부(canJoin), 입장 상태(joinStatus) 포함
- 상세: 공고 정보(회사명, 직무명), 현재 정확한 멤버 수 포함
- 목록은 여러 방을 비교하기 위한 정보, 상세는 입장 전 최종 확인용 정보

이러한 분리는 프론트엔드에서 불필요한 데이터를 조회하지 않아 네트워크 트래픽을 줄이고, API 응답 속도를 개선합니다. 사용자가 채팅방 목록을 스크롤할 때는 요약 정보만 보여주고, 특정 방을 클릭했을 때만 상세 정보를 로드하는 UX 패턴을 지원합니다.

### **권한 확인 로직 TODO 처리**

채팅방 상세 정보는 참여자만 조회할 수 있어야 하지만, 현재는 TODO로 남겨두었습니다. 이는 다음과 같은 이유입니다:

**입장 전 정보 확인 필요성**: 사용자가 채팅방에 입장하기 전에 상세 정보를 확인하고 입장 여부를 결정해야 합니다. 만약 참여자만 조회 가능하도록 제한하면, 입장 전에는 상세 정보를 볼 수 없어 사용자가 어떤 방인지 판단할 수 없습니다.

**비즈니스 정책 확정 필요**: "누가 채팅방 상세를 볼 수 있는가"는 제품 정책에 따라 달라질 수 있습니다. 예를 들어:
- 모든 사용자에게 공개 (투명성 중시)
- 동일 공고 지원자에게만 공개 (프라이버시 중시)
- 참여자에게만 공개 (보안 중시)

현재는 TODO로 남겨두고 제품 정책이 확정되면 해당 로직을 추가할 예정입니다. 코드에 주석으로 구현 방법을 명시하여 추후 작업 시 쉽게 적용할 수 있도록 했습니다.

### **중복 참여 방지 메커니즘**

채팅방 입장 시 `findByChatRoomIdAndUserIdAndKickedAtIsNull()` 메서드로 이미 참여 중인지 확인합니다. 이 메서드는 `kicked_at IS NULL` 조건을 포함하여 강퇴되지 않은 멤버만 조회합니다.

이는 다음과 같은 비즈니스 규칙을 구현합니다:
- 이미 참여 중인 사용자는 재입장 불가 (CHAT_ROOM_ALREADY_JOINED)
- 자진 퇴장한 사용자는 재입장 가능 (레코드 삭제됨)
- 강퇴당한 사용자는 재입장 불가 (kicked_at 기록됨)

### **MEMBER 역할 자동 부여**

채팅방 생성 시 방장(HOST)이 자동 등록되는 것과 달리, 입장 시에는 일반 멤버(MEMBER) 역할이 부여됩니다. 이는:
- 방장과 일반 멤버의 권한을 명확히 구분
- 방장 전용 기능(강퇴, 방 종료)을 보호
- 향후 역할 기반 권한 검증 구현 용이

`MemberRole` enum을 사용하여 역할을 타입 안전하게 관리하고, DB에는 문자열로 저장하여 향후 역할 추가 시 DDL 변경을 최소화했습니다.

### **임시값을 통한 점진적 구현**

채팅방 상세 조회와 입장 모두 JobPosting 도메인 연동이 필요한 부분은 임시값으로 처리했습니다:

**상세 조회 임시값**:
- 회사명: "회사명"
- 직무명: "직무명"

**입장 임시값**:
- jobApplicationId: 1L

이는 채팅 도메인 자체 기능을 먼저 완성하고, 도메인 간 연동은 순차적으로 진행하는 전략입니다. TODO 주석으로 연동 지점을 명시하여 추후 작업 시 누락되지 않도록 했습니다.

---

## 도메인 간 연동 계획 (TODO)

### **채팅방 상세 조회에서 필요한 연동**

**JobPosting 도메인 연동**:
- 공고 정보 조회 (`JobMasterRepository.findById`)
- 회사명, 직무명 추출

**User 도메인 연동 (선택)**:
- 방장 닉네임 조회 (목록 조회에서는 필요하지만 상세 조회에서는 선택사항)

### **채팅방 입장에서 필요한 연동**

**JobPosting 도메인 연동**:
1. jobApplicationId 조회 (`JobApplicationRepository.findByUserIdAndJobMasterId`)
2. 같은 공고 다른 방 참여 확인 (`findByJobApplicationIdAndNotKicked`)
3. 서류 제출 여부 확인 (`ApplicationDocumentRepository`)
4. AI 평가 점수 조회 및 커트라인 검증 (`AiApplicantEvaluation`)

**시스템 메시지 생성**:
- 메시지 전송 API 구현 후 "OO님이 입장했습니다" 시스템 메시지 추가
