### PR TITLE
Feature/chatmessage send read

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import com.thunder11.scuad.auth.security.UserPrincipal;
-import com.thunder11.scuad.chat.dto.request.ChatRoomCreateRequest;
 import com.thunder11.scuad.chat.dto.response.ChatRoomListResponse;
 import com.thunder11.scuad.chat.service.ChatMessageService;
 import com.thunder11.scuad.chat.service.ChatRoomService;

--- a/src/main/java/com/thunder11/scuad/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/thunder11/scuad/chat/dto/response/ChatMessageResponse.java
@@ -33,6 +33,7 @@ public class ChatMessageResponse {
         private Long fileId;
         private String fileName;
         private String fileUrl;
+        private Long fileSize;
     }
 
     // 엔티티로부터 생성하는 팩토리 메서드

--- a/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
+++ b/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
@@ -45,7 +45,8 @@ public enum ErrorCode {
     CHAT_MESSAGE_INVALID_TYPE(HttpStatus.BAD_REQUEST, "CHAT_MESSAGE_INVALID_TYPE", "유효하지 않은 메시지 타입입니다."),
     CHAT_MESSAGE_EMPTY(HttpStatus.BAD_REQUEST, "CHAT_MESSAGE_EMPTY", "메시지 내용이 비어있습니다."),
     JOB_POSTING_NOT_FOUND(HttpStatus.NOT_FOUND, "JOB_POSTING_NOT_FOUND", "채용공고를 찾을 수 없습니다."),
-    JOB_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "JOB_APPLICATION_NOT_FOUND", "지원 정보를 찾을 수 없습니다.");
+    JOB_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "JOB_APPLICATION_NOT_FOUND", "지원 정보를 찾을 수 없습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE", "since와 cursor를 동시에 사용할 수 없습니다");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 작업 내용

### **채팅 메시지 목록 조회 API 구현**

- **ChatMessageService 생성**
  - `getMessages()`: 채팅 메시지 목록 조회 (폴링 + 커서 페이징)
  - 채팅방 존재 및 멤버십 확인
  - 폴링 요청과 과거 메시지 로드 구분 처리
  - since와 cursor 동시 사용 검증
  - ChatMessage 엔티티를 ChatMessageResponse로 변환

- **폴링 방식 지원**
  - `since` 파라미터: 특정 messageId 이후의 최신 메시지 조회
  - `findNewMessagesSince()`: 폴링 전용 Repository 메서드 활용
  - 실시간 채팅을 위한 폴링 지원 (2~5초 간격 권장)
  - 폴링 응답 시 pagination=null (페이징 정보 불필요)

- **과거 메시지 로드 (무한 스크롤)**
  - `cursor` 파라미터: 커서 기반 페이징
  - `findMessagesByChatRoomIdWithCursor()`: messageId 내림차순 조회
  - 다음 페이지 존재 여부 자동 계산 (size + 1 조회)
  - pagination 객체 포함 (nextCursor, hasNext, size)

- **ChatRoomController에 엔드포인트 추가**
  - `GET /api/v1/chat-rooms/{chatRoomId}/messages`: 메시지 목록 조회
  - cursor, since, size 파라미터 지원 (cursor와 since 동시 사용 불가)
  - JWT 인증을 통한 사용자 식별

### **채팅 메시지 전송 API 구현**

- **ChatMessageService에 전송 메서드 추가**
  - `sendMessage()`: 메시지 전송 처리
  - 채팅방 존재 및 멤버십 확인
  - 메시지 타입별 검증 (TEXT, FILE)
  - ChatMessage 생성 및 저장
  - 전송 시각 자동 설정 (LocalDateTime.now())

- **메시지 검증 로직**
  - SYSTEM 타입 전송 차단 (사용자는 TEXT, FILE만 가능)
  - TEXT 타입: 내용 필수 (빈 문자열 불가)
  - FILE 타입: fileId 필수
  - 멤버십 확인 (참여자만 전송 가능)

- **ChatRoomController에 엔드포인트 추가**
  - `POST /api/v1/chat-rooms/{chatRoomId}/messages`: 메시지 전송
  - MessageSendRequest Validation 적용
  - 전송된 메시지 정보 즉시 반환 (폴링 대신 사용 가능)

### **파일 정보 DTO 확장**

- **ChatMessageResponse.FileInfo에 fileSize 추가**
  - fileId, fileName, fileUrl, fileSize (바이트 단위)
  - File 도메인 연동 시 활용 예정

---

## 설계 의도

### **폴링 방식 채택 배경**

실시간 채팅 구현을 위해 WebSocket 대신 폴링 방식을 우선 적용했습니다. 이는 MVP 단계에서 개발 복잡도를 낮추고 안정적으로 출시하기 위한 전략입니다.

**폴링 방식의 장점**:
- 구현이 단순하고 디버깅이 쉬움
- HTTP 기반으로 기존 인프라 활용 가능
- 방화벽, 프록시 환경에서도 안정적 동작
- 클라이언트 구현이 단순 (setInterval)

**폴링 방식의 단점**:
- 서버 부하 증가 (주기적인 요청)
- 네트워크 트래픽 증가
- 실시간성이 WebSocket보다 낮음 (2~5초 지연)

**향후 전환 계획**:
- 사용자 규모 및 실시간성 요구 확인 후 WebSocket(STOMP) 전환
- 메시지 저장/조회 구조는 동일하게 유지
- 전달 레이어만 교체하는 방식으로 리스크 최소화

### **폴링과 페이징의 명확한 분리**

`getMessages()` 메서드는 `since` 파라미터 유무로 폴링과 과거 메시지 로드를 구분합니다.

**초기 로드** (cursor=null, since=null):
```
GET /api/v1/chat-rooms/1/messages?size=50
→ 최신 50개 메시지 + pagination 정보
```

**과거 메시지 로드** (cursor 사용):
```
GET /api/v1/chat-rooms/1/messages?cursor=100&size=50
→ messageId < 100인 메시지 50개 + pagination 정보
```

**폴링** (since 사용):
```
GET /api/v1/chat-rooms/1/messages?since=150
→ messageId > 150인 모든 메시지 + pagination=null
```

**since와 cursor 동시 사용 금지**:
- 두 파라미터는 서로 다른 용도 (폴링 vs 페이징)
- 동시 사용 시 명시적 에러 반환 (400 Bad Request)
- API 오용 방지 및 명확한 에러 메시지 제공

**폴링 응답에서 pagination 제외**:
- 폴링은 "since 이후 모든 메시지"를 반환 (페이징 개념 없음)
- pagination=null로 응답하여 불필요한 데이터 제거
- 응답 구조 간결화 및 의미 명확화
```javascript
// 클라이언트 폴링 예시
let lastMessageId = 100;

setInterval(async () => {
  const response = await fetch(`/api/v1/chat-rooms/1/messages?since=${lastMessageId}`);
  const data = await response.json();
  
  if (data.messages.length > 0) {
    // 새 메시지 화면에 추가
    appendMessages(data.messages);
    lastMessageId = data.messages[data.messages.length - 1].messageId;
  }
}, 3000); // 3초마다 폴링
```

### **커서 기반 페이징 전략**

메시지 목록 조회에도 채팅방 목록과 동일하게 커서 기반 페이징을 적용했습니다. 메시지는 지속적으로 추가되는 데이터이므로 오프셋 기반 페이징의 page drift 문제가 더욱 심각합니다.

**Repository 메서드 구현**:
- `findMessagesByChatRoomIdWithCursor()`: messageId 내림차순 정렬
- cursor가 NULL이면 최신 메시지부터 조회
- cursor가 있으면 해당 messageId보다 작은 메시지 조회
- Soft Delete 자동 필터링 (deletedAt IS NULL)

**size + 1 조회 전략**:
- 클라이언트가 요청한 size보다 1개 더 조회
- size + 1개가 조회되면 hasNext = true
- 실제로는 size개만 반환
- 추가 카운트 쿼리 없이 다음 페이지 존재 여부 판단

### **메시지 타입별 검증**

MessageType은 TEXT, FILE, SYSTEM 3가지를 지원하지만, 사용자는 SYSTEM 타입을 직접 전송할 수 없습니다.

**TEXT 타입**:
- content 필드 필수
- 빈 문자열 불가 (trim 후 검증)
- 최대 1000자 (Validation)

**FILE 타입**:
- fileId 필드 필수
- content는 선택 (파일 설명)
- fileSize는 File 도메인 연동 후 조회
- TODO: File 도메인 연동하여 파일 존재 여부 확인

**SYSTEM 타입**:
- 사용자 전송 차단 (CHAT_MESSAGE_INVALID_TYPE)
- 시스템에서만 생성 가능
- senderId = null
- 향후 입장/퇴장/강퇴 시 자동 생성

### **멤버십 기반 권한 검증**

메시지 조회와 전송 모두 멤버십을 확인합니다. 이는:

- 참여하지 않은 사용자의 메시지 접근 차단
- 강퇴된 사용자의 메시지 전송 차단 (kicked_at IS NULL 조건)
- 채팅방 프라이버시 보호

`findByChatRoomIdAndUserIdAndKickedAtIsNull()` 메서드는:
- 활성 멤버만 조회 (강퇴되지 않은 멤버)
- 존재 여부로 권한 확인
- 없으면 CHAT_ROOM_ACCESS_DENIED 에러

### **메시지 응답 변환 로직**

`convertToResponse()` 메서드는 ChatMessage 엔티티를 ChatMessageResponse DTO로 변환합니다:

**현재 구현**:
- senderNickname: "사용자" 또는 "시스템" (임시값)
- file: fileId가 있으면 FileInfo 객체 생성 (임시값 포함 fileSize=0)
- createdAt: sentAt 필드 매핑

**향후 연동**:
- User 도메인: senderId → 실제 닉네임 조회
- File 도메인: fileId → 파일명, URL, 크기 조회

이러한 변환 로직을 별도 메서드로 캡슐화하여:
- 목록 조회와 전송에서 재사용
- 테스트 작성 용이
- 향후 연동 시 수정 지점 명확

### **전송 즉시 응답 반환**

메시지 전송 API는 전송된 메시지 정보를 즉시 반환합니다. 이는:

**낙관적 UI 업데이트**:
- 클라이언트가 전송과 동시에 화면에 메시지 표시
- 폴링 대기 없이 즉각적인 피드백
- UX 개선 (전송 지연 체감 감소)

**폴링 중복 방지**:
- 폴링으로 자신의 메시지를 다시 받는 것 방지
- 클라이언트가 lastMessageId를 응답의 messageId로 업데이트
- 다음 폴링부터는 이후 메시지만 조회

**에러 핸들링**:
- 전송 실패 시 즉시 에러 응답
- 클라이언트가 재전송 또는 에러 표시
- 네트워크 실패와 검증 실패 구분 가능

### **sentAt 자동 설정**

ChatMessage 엔티티의 `sentAt` 필드는 Builder 패턴에서 `LocalDateTime.now()`로 자동 설정됩니다. JPA Auditing의 `@CreatedDate`를 사용하지 않은 이유는:

- `sentAt`은 "메시지 전송 시각"이라는 도메인 의미
- `createdAt`(엔티티 생성 시각)과 구분
- 향후 메시지 예약 전송 등의 기능 확장 가능
- 테스트에서 시각 제어 용이

### **파일 정보 구조 확장**

FileInfo DTO에 fileSize 필드를 추가하여 향후 File 도메인 연동 시 파일 크기 정보를 제공할 수 있도록 했습니다:

- fileSize: 바이트 단위 (Long 타입)
- 클라이언트에서 "5MB", "1.2KB" 등으로 표시 가능
- 파일 다운로드 전 크기 확인 가능
- 현재는 임시값 0L 사용

### **TODO 주석을 통한 연동 지점 명시**

채팅 메시지는 User 도메인 및 File 도메인과 연동이 필요합니다.

**User 도메인 연동**:
- senderId → 닉네임 조회
- 방법: UserRepository.findById() 또는 UserService

**File 도메인 연동**:
- fileId → 파일명, URL, 크기 조회
- 파일 존재 여부 확인 (전송 시 검증)
- 방법: FileRepository 또는 FileService

**임시값 사용**:
- senderNickname: "사용자"
- fileName: "파일명"
- fileUrl: "파일URL"
- fileSize: 0L

이러한 연동은 해당 도메인 구현 완료 후 순차적으로 진행 예정입니다.

---

## 폴링 방식 → WebSocket 전환 가이드

향후 WebSocket으로 전환 시 변경되는 부분과 유지되는 부분을 명시합니다.

### **유지되는 부분** (DB 구조 및 비즈니스 로직)

- ChatMessage 엔티티 구조
- 메시지 저장 로직 (Repository, Service)
- 메시지 조회 로직 (과거 메시지 로드)
- 검증 로직 (멤버십, 메시지 타입)

### **변경되는 부분** (전달 레이어)

**폴링 방식** (현재):
```
클라이언트 → HTTP GET (폴링) → 서버 → DB 조회 → 응답
```

**WebSocket 방식** (향후):
```
클라이언트 → WebSocket 메시지 → STOMP 브로커 → 구독자들에게 전달
```

**구현 변경 사항**:
1. `getMessages(since)` 폴링 엔드포인트 제거
2. WebSocket 핸들러 추가
3. STOMP 메시지 브로커 설정
4. 메시지 전송 시 WebSocket으로 브로드캐스트
5. 클라이언트는 `/topic/chat-rooms/{chatRoomId}` 구독

**마이그레이션 전략**:
- 폴링과 WebSocket 병행 운영 가능
- 점진적 사용자 전환
- 레거시 클라이언트 지원 유지

---

## 도메인 간 연동 계획 (TODO)

### **User 도메인 연동**

**필요한 정보**:
- 발신자 닉네임 (senderId → nickname)

**연동 방법**:
- UserRepository.findById() 또는 UserService.getNickname()
- convertToResponse() 메서드에서 조회

**우선순위**: 중간 (임시값으로 동작 가능)

### **File 도메인 연동**

**필요한 정보**:
- 파일명, URL, 크기 (fileId → FileInfo)

**필요한 검증**:
- 메시지 전송 시 파일 존재 여부 확인
- 파일 소유자 확인 (보안)

**연동 방법**:
- FileRepository.findById() 또는 FileService
- sendMessage() 메서드에서 검증
- convertToResponse() 메서드에서 정보 조회

**우선순위**: 낮음 (FILE 타입 사용 전까지 연동 불필요)

### **시스템 메시지 자동 생성**

**생성 시점**:
- 채팅방 생성 시: "채팅방이 생성되었습니다"
- 입장 시: "{닉네임}님이 입장했습니다"
- 퇴장 시: "{닉네임}님이 퇴장했습니다"
- 강퇴 시: "{닉네임}님이 강퇴되었습니다"
- 방 종료 시: "채팅방이 종료되었습니다"

**구현 방법**:
- ChatMessage.createSystemMessage() 팩토리 메서드 활용
- 각 이벤트 발생 시 자동 생성
- senderId = null, messageType = SYSTEM

**우선순위**: 중간 (UX 개선)