### PR TITLE
Feature/chatroom management v1

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -207,4 +207,22 @@ public class ChatRoomController {
                 "멤버 강퇴 완료"
         );
     }
+
+    // 채팅방 종료
+    @PatchMapping("/chat-rooms/{chatRoomId}/close")
+    public ApiResponse<Void> closeChatRoom(
+            @PathVariable Long chatRoomId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        log.info("PATCH /api/v1/chat-rooms/{}/close - userId={}",
+                chatRoomId, userPrincipal.getUserId());
+
+        chatRoomService.closeChatRoom(chatRoomId, userPrincipal.getUserId());
+
+        return ApiResponse.of(
+                HttpStatus.OK.value(),
+                "CHAT_ROOM_CLOSED",
+                "채팅방 종료 완료"
+        );
+    }
 }


### PR DESCRIPTION
## 작업 내용

### **채팅방 퇴장 API 구현**

- **ChatRoomService에 퇴장 메서드 추가**
  - `leaveChatRoom()`: 채팅방 퇴장 처리
  - 채팅방 존재 및 멤버십 확인
  - 방장 퇴장 차단 (방을 먼저 종료해야 함)
  - ChatRoomMember 레코드 삭제
  - 퇴장 후 재입장 가능

- **ChatRoomController에 엔드포인트 추가**
  - `DELETE /api/v1/chat-rooms/{chatRoomId}/members/me`: 채팅방 퇴장
  - JWT 인증을 통한 사용자 식별
  - 본인만 퇴장 가능 (me 경로 사용)

### **멤버 강퇴 API 구현**

- **ChatRoomService에 강퇴 메서드 추가**
  - `kickMember()`: 멤버 강퇴 처리
  - 방장 권한 확인 (방장만 강퇴 가능)
  - 강퇴 대상 멤버 조회 및 검증
  - 같은 채팅방 멤버인지 확인
  - 방장 자신 및 다른 방장 강퇴 불가
  - ChatRoomMember의 kicked_at 설정 (Soft Delete 아님)
  - 강퇴된 멤버는 재입장 불가

- **ChatRoomController에 엔드포인트 추가**
  - `DELETE /api/v1/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}`: 멤버 강퇴
  - JWT 인증을 통한 방장 확인
  - chatRoomMemberId로 강퇴 대상 지정

### **채팅방 종료 API 구현**

- **ChatRoomService에 종료 메서드 추가**
  - `closeChatRoom()`: 채팅방 종료 처리
  - 방장 권한 확인 (방장만 종료 가능)
  - 이미 종료된 방 중복 종료 차단
  - ChatRoom의 status를 CLOSED로 변경
  - 멤버 레코드는 유지 (과거 메시지 조회 가능)
  - 종료된 방은 입장 불가

- **ChatRoomController에 엔드포인트 추가**
  - `PATCH /api/v1/chat-rooms/{chatRoomId}/close`: 채팅방 종료
  - JWT 인증을 통한 방장 확인
  - 일반 멤버는 퇴장, 방장은 종료로 구분

---

## 설계 의도

### **퇴장과 강퇴의 구분**

채팅방에서 나가는 행위를 "자진 퇴장"과 "강제 강퇴" 두 가지로 명확히 구분했습니다.

**자진 퇴장** (Leave):
- 본인이 스스로 나가는 행위
- `DELETE /members/me` 엔드포인트 사용
- ChatRoomMember 레코드 삭제
- 재입장 가능
- 일반 멤버만 가능 (방장은 불가)

**강제 강퇴** (Kick):
- 방장이 멤버를 내보내는 행위
- `DELETE /members/{chatRoomMemberId}` 엔드포인트 사용
- ChatRoomMember의 kicked_at만 설정 (레코드 유지)
- 재입장 불가
- 방장만 실행 가능

이러한 구분은:
- 사용자 의도에 따른 명확한 동작 구분
- 강퇴 이력 보존 (보안 및 관리 목적)
- 재입장 정책 차별화

### **방장의 퇴장 제한**

방장은 일반 퇴장이 불가능하고, 반드시 채팅방을 종료해야 합니다. 이는:

**책임 있는 방 관리**:
- 방장이 임의로 나가면 방이 방치됨
- 남은 멤버들의 혼란 방지
- 명확한 방 종료 프로세스 강제

**방장 부재 문제 방지**:
- 방장 없는 채팅방의 관리 불가 문제
- 방장 위임 기능이 없는 현 시스템에서 필수

방장이 나가고 싶다면:
1. 채팅방 종료 API 호출
2. status가 CLOSED로 변경
3. 더 이상 입장 불가 상태로 전환
4. 멤버들은 각자 퇴장하거나 메시지 조회 가능

### **강퇴 시 kicked_at 설정 전략**

강퇴된 멤버의 레코드를 삭제하지 않고 `kicked_at` 필드만 설정하는 이유는:

**재입장 차단**:
- `existsKickedMember()` 메서드로 강퇴 여부 확인 (PR #3에서 구현)
- kicked_at이 NULL이 아니면 재입장 차단
- 영구적인 출입 금지 구현

**이력 보존**:
- 누가 언제 강퇴되었는지 기록
- 분쟁 발생 시 증거 자료
- 관리자 모니터링 가능

**통계 및 분석**:
- 채팅방별 강퇴 빈도 분석
- 문제 사용자 패턴 파악
- 서비스 개선 자료

**Soft Delete와의 차이**:
- Soft Delete (deleted_at): 데이터 복구 가능, 일시적
- Kicked (kicked_at): 재입장 차단, 영구적

### **강퇴 권한 검증**

강퇴는 방장만 가능하며, 여러 검증을 거칩니다:

**방장 권한 확인**:
```java
boolean isHost = chatRoomMemberRepository.isHostOfRoom(chatRoomId, userId);
```
- Repository 메서드로 방장 여부 확인
- 권한 없으면 CHAT_ROOM_HOST_ONLY 에러

**강퇴 대상 검증**:
1. 대상 멤버가 존재하는가?
2. 같은 채팅방의 멤버인가?
3. 방장 자신을 강퇴하려는가?
4. 대상이 방장인가?

이러한 다층 검증으로:
- URL 조작 공격 방지
- 방장 간 충돌 방지
- 시스템 일관성 보장

### **채팅방 종료와 삭제의 구분**

채팅방 종료(Close)는 삭제(Delete)가 아닙니다:

**종료** (status = CLOSED):
- ChatRoom 레코드는 그대로 유지
- ChatRoomMember 레코드도 유지
- 더 이상 입장 불가
- 메시지 이력 보존
- 과거 데이터 조회 가능
- 참여했던 멤버는 메시지 조회 계속 가능

**삭제** (deleted_at 설정):
- 구현하지 않음
- 데이터 보존 정책에 따라 추후 결정
- 법적 요구사항 고려 필요

**종료 시 멤버 레코드 유지 이유**:
- 채팅방 종료는 "새 입장 차단"이지 "데이터 삭제"가 아님
- 멤버들은 여전히 과거 메시지 조회 가능
- 이력 보존 및 데이터 무결성 유지
- 추후 "참여했던 채팅방" 기능 구현 가능
- 법적 분쟁 시 증거 자료로 활용

**종료 vs 전체 퇴장**:
- 종료: status=CLOSED, 멤버 레코드 유지, 입장 불가
- 전체 퇴장: 각 멤버가 개별적으로 DELETE /members/me 호출
- 현재는 자동 퇴장 구현하지 않음 (명시적 설계 결정)
- 멤버들이 원하면 각자 퇴장, 원치 않으면 메시지 보관 가능

**종료 후 상태**:
- 채팅방 목록에서 표시 안 됨 (status != ACTIVE 필터링)
- 상세 조회는 가능 (참여 이력 확인)
- 메시지 조회 가능 (참여했던 멤버만)
- 새로운 멤버 입장 차단 (joinChatRoom에서 status 확인)

### **중복 종료 방지**

이미 종료된 채팅방을 다시 종료하려는 시도를 차단합니다:
```java
if (chatRoom.getStatus() == RoomStatus.CLOSED) {
    throw new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND);
}
```

**CHAT_ROOM_NOT_FOUND 사용 이유**:
- 종료된 방은 "더 이상 존재하지 않음"으로 간주
- 새로운 에러 코드보다 기존 코드 재사용
- 클라이언트 입장에서 "이미 없는 방"과 동일한 처리

### **멤버 삭제 vs kicked_at 설정**

퇴장과 강퇴에서 데이터 처리 방식이 다릅니다:

| 구분 | 퇴장 (Leave) | 강퇴 (Kick) |
|------|-------------|------------|
| 동작 | 레코드 삭제 | kicked_at 설정 |
| 재입장 | 가능 | 불가 |
| 이력 | 없음 | 보존 |
| 용도 | 자유로운 나가기 | 영구 차단 |

**퇴장 시 레코드 삭제 이유**:
- 자진 퇴장은 일시적 행위로 간주
- 다시 들어올 수 있어야 함
- 불필요한 레코드 제거

**강퇴 시 레코드 유지 이유**:
- 강퇴는 관리 행위로 이력 필요
- 재입장 차단 메커니즘
- 책임 추적 가능

### **방장 전용 기능의 에러 처리**

강퇴와 종료는 방장만 가능한 기능입니다. 일반 멤버가 시도 시 명확한 에러를 반환합니다:
```java
if (!isHost) {
    throw new ApiException(ErrorCode.CHAT_ROOM_HOST_ONLY);
}
```

**CHAT_ROOM_HOST_ONLY 에러**:
- 방장 전용 기능임을 명시
- 403 Forbidden (권한 부족)
- 클라이언트에서 UI 제어 가능

### **/members/me vs /members/{id} 경로 설계**

퇴장은 `/me`, 강퇴는 `/{chatRoomMemberId}`를 사용합니다:

**`/members/me` (퇴장)**:
- RESTful 관례 (본인 리소스 표현)
- JWT에서 자동으로 userId 추출
- URL 조작 공격 불가
- 본인만 퇴장 가능

**`/members/{chatRoomMemberId}` (강퇴)**:
- 특정 멤버 지정
- 방장이 대상 선택
- chatRoomMemberId로 정확한 타겟팅

### **TODO 주석을 통한 시스템 메시지 예정**

각 메서드에 시스템 메시지 생성 TODO를 남겼습니다:

**퇴장 시**: "OO님이 퇴장했습니다"
**강퇴 시**: "OO님이 강퇴되었습니다"
**종료 시**: "채팅방이 종료되었습니다"

**구현 방법**:
- ChatMessage.createSystemMessage() 팩토리 메서드 활용
- senderId = null, messageType = SYSTEM
- 자동으로 메시지 생성 및 저장

**구현 시점**:
- User 도메인 연동 후 (닉네임 필요)
- 메시지 기능 완성 후
- UX 개선 단계

---

## API 명세

### 1. 채팅방 퇴장
```
DELETE /api/v1/chat-rooms/{chatRoomId}/members/me
Authorization: Bearer {JWT}

Response 200 OK:
{
  "status": 200,
  "code": "CHAT_ROOM_LEFT",
  "message": "채팅방 퇴장 완료"
}

Error Cases:
- 404: CHAT_ROOM_NOT_FOUND (채팅방 없음)
- 404: CHAT_MEMBER_NOT_FOUND (멤버가 아님)
- 403: CHAT_ROOM_HOST_ONLY (방장은 퇴장 불가)
```

### 2. 멤버 강퇴
```
DELETE /api/v1/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}
Authorization: Bearer {JWT}

Response 200 OK:
{
  "status": 200,
  "code": "MEMBER_KICKED",
  "message": "멤버 강퇴 완료"
}

Error Cases:
- 404: CHAT_ROOM_NOT_FOUND (채팅방 없음)
- 403: CHAT_ROOM_HOST_ONLY (방장이 아님)
- 404: CHAT_MEMBER_NOT_FOUND (멤버 없음 또는 다른 방)
- 400: INVALID_INPUT_VALUE (자신을 강퇴 시도)
```

### 3. 채팅방 종료
```
PATCH /api/v1/chat-rooms/{chatRoomId}/close
Authorization: Bearer {JWT}

Response 200 OK:
{
  "status": 200,
  "code": "CHAT_ROOM_CLOSED",
  "message": "채팅방 종료 완료"
}

Error Cases:
- 404: CHAT_ROOM_NOT_FOUND (채팅방 없음 또는 이미 종료됨)
- 403: CHAT_ROOM_HOST_ONLY (방장이 아님)
```

---

## 비즈니스 플로우

### 일반 멤버의 채팅방 이용 종료
```
1. 사용자: "나가기" 클릭
2. DELETE /members/me 호출
3. ChatRoomMember 레코드 삭제
4. 성공 응답
5. 채팅방 목록으로 이동
6. 재입장 가능
```

### 방장의 채팅방 이용 종료
```
1. 방장: "방 종료" 클릭
2. PATCH /close 호출
3. ChatRoom.status = CLOSED (멤버 레코드는 유지)
4. 성공 응답
5. 멤버들은 입장 불가 상태가 되나, 과거 메시지 조회는 가능
6. 멤버들이 원하면 각자 DELETE /members/me로 퇴장
7. TODO: 종료 알림 시스템 메시지
```

### 방장의 문제 멤버 강퇴
```
1. 방장: 멤버 목록에서 "강퇴" 클릭
2. DELETE /members/{chatRoomMemberId} 호출
3. 권한 확인 (방장인가?)
4. ChatRoomMember.kicked_at 설정 (레코드 유지)
5. 성공 응답
6. 강퇴된 사용자는 재입장 차단됨
7. 강퇴된 사용자는 과거 메시지 조회는 가능
8. TODO: 시스템 메시지 전송
```

---