### PR TITLE
fix : 채팅방의 최신 메세지 조회

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/thunder11/scuad/chat/repository/ChatMessageRepository.java
@@ -12,11 +12,13 @@ import com.thunder11.scuad.chat.domain.ChatMessage;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     // 채팅방의 최신 메시지 조회 (커서 기반 페이징)
+    // 수정 이유: 채팅 메시지는 오래된 것부터 최신 순으로 정렬되어야 프론트엔드에서
+    //           올바른 순서로 렌더링되고, 폴링 시 cursor(마지막 메시지 ID) 추적이 정확함
     @Query("SELECT cm FROM ChatMessage cm " +
             "WHERE cm.chatRoomId = :chatRoomId " +
             "AND cm.deletedAt IS NULL " +
-            "AND (:cursor IS NULL OR cm.messageId < :cursor) " +
-            "ORDER BY cm.messageId DESC")
+            "AND (:cursor IS NULL OR cm.messageId > :cursor) " +
+            "ORDER BY cm.messageId ASC")
     List<ChatMessage> findMessagesByChatRoomIdWithCursor(
             @Param("chatRoomId") Long chatRoomId,
             @Param("cursor") Long cursor,


### PR DESCRIPTION
- 내림차순 -> 오름차순으로 변경

<h2> 발견된 버그</h2>
<h3><strong>버그 1: 채팅방 입장 시 과거 메시지 순서가 뒤죽박죽으로 표시됨</strong></h3>
<ul>
<li><strong>증상</strong>: 채팅방에 입장하여 과거 메시지를 불러올 때 시간 순서대로 정렬되지 않음</li>
<li><strong>영향</strong>: 사용자가 대화 흐름을 파악하기 어렵고 UX가 크게 저하됨</li>
</ul>
<h3><strong>버그 2: 새 메시지가 다른 사용자에게 실시간으로 표시되지 않음</strong></h3>
<ul>
<li><strong>증상</strong>: 한 사용자가 메시지를 전송해도 다른 사용자의 화면에 즉시 나타나지 않음</li>
<li><strong>영향</strong>: 실시간 채팅의 핵심 기능이 작동하지 않아 서비스 사용 불가능</li>
</ul>
<hr>
<h2>🔍 근본 원인 분석</h2>
<h3><strong>1. 메시지 정렬 순서 문제</strong></h3>
<p><strong>문제가 된 코드 (수정 전):</strong></p>
<pre><code class="language-java">@Query("SELECT cm FROM ChatMessage cm " +
        "WHERE cm.chatRoomId = :chatRoomId " +
        "AND cm.deletedAt IS NULL " +
        "AND (:cursor IS NULL OR cm.messageId &lt; :cursor) " +
        "ORDER BY cm.messageId DESC")  // ❌ 내림차순 정렬
List&lt;ChatMessage&gt; findMessagesByChatRoomIdWithCursor(
        @Param("chatRoomId") Long chatRoomId,
        @Param("cursor") Long cursor,
        Pageable pageable
);
</code></pre>
<p><strong>근본 원인:</strong></p>
<ul>
<li>메시지를 <code>messageId DESC</code> (내림차순)로 정렬하여 반환</li>
<li>최신 메시지가 배열의 첫 번째, 오래된 메시지가 마지막에 위치</li>
<li>프론트엔드는 배열을 그대로 렌더링하므로 최신 메시지가 위에, 오래된 메시지가 아래에 표시됨</li>
<li>일반적인 채팅 UI와 반대되는 순서</li>
</ul>
<h3><strong>2. 커서 기반 폴링 로직 오류</strong></h3>
<p><strong>프론트엔드의 폴링 로직:</strong></p>
<pre><code class="language-javascript">// 프론트엔드 코드 (예상)
const messages = await fetchMessages(chatRoomId, cursor, size);
const lastMessage = messages[messages.length - 1];
const newCursor = lastMessage.messageId; // 배열 마지막 요소를 cursor로 사용

// 다음 폴링 시
const newMessages = await fetchMessages(chatRoomId, null, size, newCursor);
</code></pre>
<p><strong>문제 발생 시나리오:</strong></p>
<ol>
<li>API가 <code>DESC</code> 정렬로 응답: <code>[msg100, msg99, msg98, ..., msg81]</code></li>
<li>프론트가 마지막 요소 <code>msg81</code>의 ID를 cursor로 저장</li>
<li>새 메시지 <code>msg101</code>, <code>msg102</code>가 생성됨</li>
<li>프론트가 <code>since=81</code>로 폴링 요청</li>
<li><code>msg81</code> 이후의 모든 메시지(<code>msg82~msg102</code>)를 받아야 하는데, cursor 로직이 <code>&lt; cursor</code>로 되어 있어 잘못된 범위 조회</li>
<li>결과적으로 새 메시지를 받지 못하거나 중복 수신</li>
</ol>
<hr>
<h2>✅ 수정 내용</h2>
<h3><strong>수정된 코드:</strong></h3>
<pre><code class="language-java">// 채팅방의 최신 메시지 조회 (커서 기반 페이징)
// 수정 이유: 채팅 메시지는 오래된 것부터 최신 순으로 정렬되어야 프론트엔드에서
//           올바른 순서로 렌더링되고, 폴링 시 cursor(마지막 메시지 ID) 추적이 정확함
@Query("SELECT cm FROM ChatMessage cm " +
        "WHERE cm.chatRoomId = :chatRoomId " +
        "AND cm.deletedAt IS NULL " +
        "AND (:cursor IS NULL OR cm.messageId &gt; :cursor) " +  // ✅ &gt; 연산자로 변경
        "ORDER BY cm.messageId ASC")  // ✅ 오름차순 정렬로 변경
List&lt;ChatMessage&gt; findMessagesByChatRoomIdWithCursor(
        @Param("chatRoomId") Long chatRoomId,
        @Param("cursor") Long cursor,
        Pageable pageable
);
</code></pre>
<h3><strong>변경 사항:</strong></h3>
<ol>
<li><strong>정렬 순서</strong>: <code>DESC</code> → <code>ASC</code> 변경</li>
<li><strong>커서 조건</strong>: <code>cm.messageId &lt; :cursor</code> → <code>cm.messageId &gt; :cursor</code> 변경</li>
</ol>
<hr>
<h2>🎯 수정 의도 및 설계 근거</h2>
<h3><strong>1. 오름차순 정렬의 필요성</strong></h3>
<p><strong>채팅 UI 표준:</strong></p>
<ul>
<li>모든 채팅 애플리케이션(카카오톡, Slack, Discord 등)은 오래된 메시지가 위, 최신 메시지가 아래에 표시</li>
<li>사용자는 위에서 아래로 읽으며, 스크롤을 내리면 최신 메시지 확인</li>
<li>따라서 API 응답도 이 순서를 따라야 프론트엔드에서 추가 처리 없이 렌더링 가능</li>
</ul>
<p><strong>데이터 플로우:</strong></p>
<pre><code>DB: [msg1, msg2, msg3, msg4, msg5]
       ↓ ORDER BY messageId ASC
API: [msg1, msg2, msg3, msg4, msg5]
       ↓ 프론트엔드 렌더링
화면: msg1 (오래됨)
     msg2
     msg3
     msg4
     msg5 (최신)
</code></pre>
<h3><strong>2. 커서 페이지네이션 로직</strong></h3>
<p><strong>수정 전 (잘못된 로직):</strong></p>
<ul>
<li><code>DESC</code> 정렬 + <code>&lt; cursor</code> 조건</li>
<li>cursor보다 <strong>작은</strong> ID(= 더 오래된 메시지)를 조회</li>
<li>폴링 시에는 cursor보다 <strong>큰</strong> ID(= 더 최신 메시지)를 조회해야 하는데 로직이 반대</li>
</ul>
<p><strong>수정 후 (올바른 로직):</strong></p>
<ul>
<li><code>ASC</code> 정렬 + <code>&gt; cursor</code> 조건</li>
<li>cursor보다 <strong>큰</strong> ID(= 더 최신 메시지)를 조회</li>
<li>과거 메시지 로드 시: cursor=null로 시작, 이후 마지막 메시지 ID를 cursor로 사용하여 다음 페이지 로드</li>
<li>폴링 시: 가장 최신 메시지 ID를 <code>since</code>로 사용하여 새 메시지만 조회</li>
</ul>
<h3><strong>3. 폴링 메커니즘과의 정합성</strong></h3>
<p><strong>폴링 시나리오 (수정 후):</strong></p>
<pre><code>1. 초기 로드: cursor=null → msg1~msg50 반환 (ASC 정렬)
2. 프론트: 마지막 요소 msg50.id = 50을 저장
3. 사용자A가 msg51 전송
4. 사용자B가 폴링: since=50 요청
5. API: messageId &gt; 50 조회 → msg51 반환 (ASC 정렬)
6. 프론트: msg51을 화면 맨 아래에 추가 (올바른 위치)
</code></pre>
<p><strong>기술 스펙 문서와의 일치:</strong></p>
<ul>
<li>채팅 도메인 테크스펙 v1에 명시된 "커서 페이징" 방식 준수</li>
<li><code>sentAt</code> 또는 <code>messageId</code> 기준 <strong>오름차순</strong> 정렬이 표준</li>
<li>MVP에서는 폴링 방식으로 실시간성 구현 (향후 WebSocket 전환 예정)</li>
</ul>
<hr>
