### PR TITLE
fix : chatmessage file

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -5,6 +5,7 @@ import com.thunder11.scuad.chat.dto.request.MessageSendRequest;
 import com.thunder11.scuad.chat.dto.response.ChatMessageListResponse;
 import com.thunder11.scuad.chat.dto.response.ChatMessageResponse;
 import com.thunder11.scuad.chat.dto.response.ChatRoomDetailResponse;
+import com.thunder11.scuad.chat.domain.type.MessageType;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -28,6 +29,7 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
     private final ChatMessageService chatMessageService;
+    private final com.thunder11.scuad.file.service.FileStorageService fileStorageService;
 
     // 공고별 채팅방 목록 조회
     @GetMapping("/job-postings/{jobMasterId}/chat-rooms")
@@ -148,6 +150,8 @@ public class ChatRoomController {
     }
 
     // 메시지 전송 (multipart/form-data 지원)
+    // 수정 이유: FILE 타입 메시지 전송 시 파일을 S3에 업로드하고 fileId를 생성하여
+    //           MessageSendRequest에 포함시켜야 서비스에서 정상 처리 가능
     @PostMapping(value = "/chat-rooms/{chatRoomId}/messages", consumes = {"multipart/form-data"})
     public ApiResponse<ChatMessageResponse> sendMessage(
             @PathVariable Long chatRoomId,
@@ -156,13 +160,44 @@ public class ChatRoomController {
             @RequestParam(value = "file", required = false) org.springframework.web.multipart.MultipartFile file,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        log.info("POST /api/v1/chat-rooms/{}/messages - messageType={}, content={}, userId={}",
-                chatRoomId, messageType, content, userPrincipal.getUserId());
+        log.info("POST /api/v1/chat-rooms/{}/messages - messageType={}, content={}, hasFile={}, userId={}",
+                chatRoomId, messageType, content, (file != null), userPrincipal.getUserId());
 
-        // DTO 생성 (String -> MessageType 변환)
+        // MessageType 변환
+        MessageType msgType = MessageType.valueOf(messageType.toUpperCase());
+        
+        Long fileId = null;
+        
+        // FILE 타입인 경우 파일 업로드 처리
+        if (msgType == MessageType.FILE) {
+            if (file == null || file.isEmpty()) {
+                log.warn("FILE 타입 메시지인데 파일이 없음: chatRoomId={}, userId={}", chatRoomId, userPrincipal.getUserId());
+                throw new com.thunder11.scuad.common.exception.ApiException(
+                    com.thunder11.scuad.common.exception.ErrorCode.INVALID_INPUT_VALUE
+                );
+            }
+            
+            // 파일 S3 업로드 및 fileId 생성
+            try {
+                com.thunder11.scuad.file.domain.FileObject fileObject = fileStorageService.uploadFile(
+                    file, 
+                    "chat-files/" + chatRoomId
+                );
+                fileId = fileObject.getId();
+                log.info("파일 업로드 완료: fileId={}, originalName={}, size={}", 
+                    fileId, file.getOriginalFilename(), file.getSize());
+            } catch (Exception e) {
+                log.error("파일 업로드 실패: chatRoomId={}, userId={}, error={}", 
+                    chatRoomId, userPrincipal.getUserId(), e.getMessage());
+                throw e;
+            }
+        }
+
+        // DTO 생성
         MessageSendRequest request = MessageSendRequest.builder()
-                .messageType(com.thunder11.scuad.chat.domain.type.MessageType.valueOf(messageType.toUpperCase()))
+                .messageType(msgType)
                 .content(content)
+                .fileId(fileId)
                 .build();
 
         ChatMessageResponse response = chatMessageService.sendMessage(


### PR DESCRIPTION
- FILE 타입 메시지 전송 시 파일을 S3에 업로드하고 fileId를 생성하여 MessageSendRequest에 포함

<h2>발견된 버그</h2>
<h3><strong>파일/이미지 메시지 전송 시 400 Bad Request 발생</strong></h3>
<p><strong>증상:</strong></p>
<ul>
<li>텍스트 메시지(<code>messageType: TEXT</code>)는 정상 전송됨</li>
<li>파일 메시지(<code>messageType: FILE</code>) 전송 시 400 에러 발생</li>
<li>요청 형식: <code>multipart/form-data</code>, 필드 <code>messageType="FILE"</code> + <code>file={파일객체}</code></li>
<li>테스트 파일: PDF, 약 110KB (10MB 이하 정상 범위)</li>
</ul>
<p><strong>에러 로그 (추정):</strong></p>
<pre><code>ChatMessageService: FILE 타입 메시지인데 fileId가 null
ErrorCode: CHAT_MESSAGE_INVALID_TYPE
</code></pre>
<p><strong>영향도:</strong></p>
<ul>
<li>사용자가 채팅방에서 파일을 전송할 수 없음</li>
<li>이미지, PDF 등 모든 파일 첨부 기능 사용 불가</li>
<li>채팅의 핵심 기능 중 하나가 작동하지 않음</li>
</ul>
<hr>
<h2>근본 원인 분석</h2>
<h3><strong>1. 컨트롤러에서 파일 처리 누락</strong></h3>
<p><strong>문제가 된 코드 (수정 전):</strong></p>
<pre><code class="language-java">@PostMapping(value = "/chat-rooms/{chatRoomId}/messages", 
             consumes = {"multipart/form-data"})
public ApiResponse&lt;ChatMessageResponse&gt; sendMessage(
        @PathVariable Long chatRoomId,
        @RequestParam("messageType") String messageType,
        @RequestParam(value = "content", required = false) String content,
        @RequestParam(value = "file", required = false) MultipartFile file,  // ❌ 받기만 하고 처리 안 함
        @AuthenticationPrincipal UserPrincipal userPrincipal
) {
    // DTO 생성 (String -&gt; MessageType 변환)
    MessageSendRequest request = MessageSendRequest.builder()
            .messageType(MessageType.valueOf(messageType.toUpperCase()))
            .content(content)
            .build();  // ❌ fileId를 설정하지 않음

    ChatMessageResponse response = chatMessageService.sendMessage(
            chatRoomId,
            userPrincipal.getUserId(),
            request  // ❌ fileId=null로 전달
    );
    
    return ApiResponse.of(...);
}
</code></pre>
<p><strong>문제점:</strong></p>
<ol>
<li><code>MultipartFile file</code> 파라미터를 받지만 <strong>실제로 사용하지 않음</strong></li>
<li><strong>파일을 S3에 업로드하지 않음</strong> → <code>fileId</code> 생성 안 됨</li>
<li><code>MessageSendRequest</code>에 <strong>fileId를 설정하지 않음</strong> (null 상태)</li>
<li>서비스에 <code>fileId=null</code>인 채로 전달</li>
</ol>
<h3><strong>2. 서비스 레이어의 Validation 로직</strong></h3>
<p><strong>ChatMessageService.java의 검증 코드:</strong></p>
<pre><code class="language-java">// 5. 파일 메시지 검증
if (request.getMessageType() == MessageType.FILE &amp;&amp; request.getFileId() == null) {
    log.warn("fileId 없는 FILE 타입 메시지: chatRoomId={}, userId={}", chatRoomId, userId);
    throw new ApiException(ErrorCode.CHAT_MESSAGE_INVALID_TYPE);
}

// 6. 파일 존재 여부 확인
if (request.getMessageType() == MessageType.FILE) {
    if (!fileObjectRepository.existsByIdAndNotDeleted(request.getFileId())) {
        log.warn("존재하지 않는 파일로 메시지 전송 시도: chatRoomId={}, userId={}, fileId={}",
                chatRoomId, userId, request.getFileId());
        throw new ApiException(ErrorCode.FILE_NOT_FOUND);
    }
}
</code></pre>
<p><strong>Validation 실패 시나리오:</strong></p>
<pre><code>1. 프론트: messageType=FILE, file=&lt;PDF객체&gt; 전송
2. 컨트롤러: file 파라미터 받음 → 업로드 안 함 → fileId=null
3. 서비스: messageType=FILE인데 fileId=null 확인
4. 서비스: ApiException(CHAT_MESSAGE_INVALID_TYPE) 발생
5. 클라이언트: 400 Bad Request 수신
</code></pre>
<h3><strong>3. 설계 의도와의 불일치</strong></h3>
<p><strong>테크스펙 문서의 설계:</strong></p>
<ul>
<li>채팅 도메인 테크스펙 v1: "multipart/form-data 지원"</li>
<li>파일 전송 플로우: 파일 수신 → S3 업로드 → fileId 생성 → 메시지 저장</li>
<li><code>chat_messages</code> 테이블: <code>file_id</code> 컬럼으로 <code>file_objects</code> 테이블 참조</li>
</ul>
<p><strong>현재 구현의 문제:</strong></p>
<ul>
<li>컨트롤러가 파일을 받기만 하고 업로드하지 않음</li>
<li>서비스 레이어는 이미 fileId가 있다고 가정하고 구현됨</li>
<li>컨트롤러와 서비스 간의 계약이 불완전함</li>
</ul>
<hr>
<h2>✅ 수정 내용</h2>
<h3><strong>수정된 코드:</strong></h3>
<pre><code class="language-java">// 수정 이유: FILE 타입 메시지 전송 시 파일을 S3에 업로드하고 fileId를 생성하여
//           MessageSendRequest에 포함시켜야 서비스에서 정상 처리 가능
@PostMapping(value = "/chat-rooms/{chatRoomId}/messages", 
             consumes = {"multipart/form-data"})
public ApiResponse&lt;ChatMessageResponse&gt; sendMessage(
        @PathVariable Long chatRoomId,
        @RequestParam("messageType") String messageType,
        @RequestParam(value = "content", required = false) String content,
        @RequestParam(value = "file", required = false) MultipartFile file,
        @AuthenticationPrincipal UserPrincipal userPrincipal
) {
    log.info("POST /api/v1/chat-rooms/{}/messages - messageType={}, content={}, hasFile={}, userId={}",
            chatRoomId, messageType, content, (file != null), userPrincipal.getUserId());

    // MessageType 변환
    MessageType msgType = MessageType.valueOf(messageType.toUpperCase());
    
    Long fileId = null;
    
    // ✅ FILE 타입인 경우 파일 업로드 처리
    if (msgType == MessageType.FILE) {
        // 파일 검증
        if (file == null || file.isEmpty()) {
            log.warn("FILE 타입 메시지인데 파일이 없음: chatRoomId={}, userId={}", 
                    chatRoomId, userPrincipal.getUserId());
            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE);
        }
        
        // ✅ 파일 S3 업로드 및 fileId 생성
        try {
            FileObject fileObject = fileStorageService.uploadFile(
                file, 
                "chat-files/" + chatRoomId  // S3 경로: chat-files/{chatRoomId}/
            );
            fileId = fileObject.getId();
            log.info("파일 업로드 완료: fileId={}, originalName={}, size={}", 
                fileId, file.getOriginalFilename(), file.getSize());
        } catch (Exception e) {
            log.error("파일 업로드 실패: chatRoomId={}, userId={}, error={}", 
                chatRoomId, userPrincipal.getUserId(), e.getMessage());
            throw e;
        }
    }

    // ✅ DTO 생성 (fileId 포함)
    MessageSendRequest request = MessageSendRequest.builder()
            .messageType(msgType)
            .content(content)
            .fileId(fileId)  // ✅ 업로드된 파일의 ID 설정
            .build();

    ChatMessageResponse response = chatMessageService.sendMessage(
            chatRoomId,
            userPrincipal.getUserId(),
            request
    );

    return ApiResponse.of(
            HttpStatus.CREATED.value(),
            "MESSAGE_SENT",
            "메시지 전송 완료",
            response
    );
}
</code></pre>
<h3><strong>변경 사항 요약:</strong></h3>
<ol>
<li>
<p><strong>FileStorageService 의존성 추가</strong></p>
<pre><code class="language-java">private final FileStorageService fileStorageService;
</code></pre>
</li>
<li>
<p><strong>FILE 타입 분기 처리 추가</strong></p>
<ul>
<li><code>messageType=FILE</code>인 경우 파일 존재 여부 검증</li>
<li>파일이 없으면 즉시 400 에러 반환</li>
</ul>
</li>
<li>
<p><strong>파일 업로드 로직 구현</strong></p>
<ul>
<li><code>fileStorageService.uploadFile()</code> 호출</li>
<li>S3 경로: <code>chat-files/{chatRoomId}/</code></li>
<li>업로드 성공 시 <code>FileObject</code> 반환</li>
</ul>
</li>
<li>
<p><strong>fileId 추출 및 설정</strong></p>
<ul>
<li><code>fileObject.getId()</code>로 fileId 추출</li>
<li><code>MessageSendRequest</code>에 fileId 설정</li>
</ul>
</li>
<li>
<p><strong>로깅 강화</strong></p>
<ul>
<li>파일 업로드 성공/실패 로그 추가</li>
<li>파일명, 크기 정보 기록</li>
</ul>
</li>
</ol>
<hr>
<h2>수정 의도 및 설계 근거</h2>
<h3><strong>1. 파일 업로드 플로우 완성</strong></h3>
<p><strong>올바른 처리 흐름:</strong></p>
<pre><code>프론트엔드                컨트롤러                서비스                  S3
    |                      |                      |                      |
    | multipart 요청       |                      |                      |
    |---------------------&gt;|                      |                      |
    |                      | 파일 검증            |                      |
    |                      | uploadFile()         |                      |
    |                      |---------------------&gt;|                      |
    |                      |                      | S3 업로드            |
    |                      |                      |---------------------&gt;|
    |                      |                      |&lt;---------------------|
    |                      |&lt;---------------------|                      |
    |                      | fileId 획득          |                      |
    |                      | sendMessage(fileId)  |                      |
    |                      |---------------------&gt;|                      |
    |                      |                      | DB 저장 (fileId)     |
    |                      |                      | (chat_messages)      |
    |&lt;---------------------|&lt;---------------------|                      |
    | 201 Created          |                      |                      |
</code></pre>
<p><strong>설계 원칙:</strong></p>
<ul>
<li><strong>단일 책임 원칙 (SRP)</strong>: 컨트롤러는 파일 업로드, 서비스는 메시지 저장</li>
<li><strong>계층별 역할 분리</strong>: 컨트롤러에서 인프라(S3) 처리, 서비스에서 비즈니스 로직</li>
<li><strong>실패 시 롤백</strong>: 파일 업로드 실패 시 메시지 저장 전에 예외 발생</li>
</ul>
<h3><strong>2. S3 경로 구조 설계</strong></h3>
<p><strong>파일 저장 경로:</strong></p>
<pre><code>s3://bucket-name/chat-files/{chatRoomId}/{uuid}.{extension}

예시:
s3://scuad-dev/chat-files/1/a1b2c3d4-e5f6-7890-abcd-ef1234567890.pdf
s3://scuad-dev/chat-files/1/f6e5d4c3-b2a1-0987-6543-210fedcba987.png
</code></pre>
<p><strong>설계 근거:</strong></p>
<ul>
<li><strong>채팅방별 격리</strong>: <code>chat-files/{chatRoomId}/</code>로 채팅방별 파일 관리</li>
<li><strong>UUID 사용</strong>: 파일명 중복 방지, 보안 강화</li>
<li><strong>확장자 보존</strong>: 원본 확장자 유지로 파일 타입 식별 용이</li>
<li><strong>계층 구조</strong>: 향후 채팅방 단위 파일 정리/삭제 가능</li>
</ul>
<h3><strong>3. 에러 핸들링 전략</strong></h3>
<p><strong>파일 업로드 단계별 에러 처리:</strong></p>

시나리오 | 검증 위치 | 에러 코드 | HTTP Status
-- | -- | -- | --
FILE 타입인데 파일 없음 | 컨트롤러 | INVALID_INPUT_VALUE | 400
S3 업로드 실패 | FileStorageService | FILE_UPLOAD_ERROR | 500
fileId로 파일 못 찾음 | 서비스 | FILE_NOT_FOUND | 404
채팅방 멤버 아님 | 서비스 | CHAT_ROOM_ACCESS_DENIED | 403