### PR TITLE
feat(auth): 로그아웃 API 구현 및 전체 디바이스 토큰 무효화

### DIFF
--- a/src/main/java/com/thunder11/scuad/auth/controller/AuthController.java
+++ b/src/main/java/com/thunder11/scuad/auth/controller/AuthController.java
@@ -1,5 +1,8 @@
 package com.thunder11.scuad.auth.controller;
 
+import com.thunder11.scuad.auth.security.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -83,7 +86,7 @@ public class AuthController {
     }
 
     // Access Token 재발급
-// Refresh Token을 쿠키에서 받아서 새로운 Access Token과 Refresh Token 발급
+    // Refresh Token을 쿠키에서 받아서 새로운 Access Token과 Refresh Token 발급
     @PostMapping("/refresh")
     public TokenRefreshResponse refreshToken(
             @CookieValue(name = "refreshToken") String refreshToken,
@@ -107,5 +110,33 @@ public class AuthController {
         log.info("토큰 재발급 완료, 새 Refresh Token을 HttpOnly 쿠키로 설정");
 
         return tokenResponse;
+    }
+
+    // 로그아웃 (전체 디바이스 무효화)
+    // 해당 사용자의 모든 Refresh Token을 철회하여 재발급 차단
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            HttpServletResponse response
+    ) {
+        Long userId = userPrincipal.getUserId();
+        log.info("로그아웃 요청: userId={}", userId);
+
+        // 해당 사용자의 모든 Refresh Token 철회
+        authService.logoutAllDevices(userId);
+
+        // Refresh Token 쿠키 만료 처리
+        ResponseCookie expiredCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/v1/auth")
+                .maxAge(0)  // 즉시 만료
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", expiredCookie.toString());
+        log.info("로그아웃 완료: userId={}, 모든 디바이스에서 Refresh Token 철회됨", userId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/thunder11/scuad/auth/domain/AuthRefreshToken.java
+++ b/src/main/java/com/thunder11/scuad/auth/domain/AuthRefreshToken.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import jakarta.persistence.*;
 import lombok.*;
 
-
 // Access Token 재발급을 위한 Refresh Token 정보를 관리
 // 로그아웃 시 무효화(revoke)하여 재발급 방지
 @Entity
@@ -20,33 +19,25 @@ public class AuthRefreshToken {
     private Long tokenId;
 
     // 토큰 소유자
-    // LAZY 로딩: 토큰 검증 시 User 정보는 필요할 때만 로딩
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-
     // 보안을 위해 원본 토큰을 해시하여 저장
-    // 유니크 제약으로 중복 방지
     @Column(name = "token_value", nullable = false, length = 64, unique = true)
     private String tokenValue;
-
 
     // 토큰 만료 시각
     @Column(name = "expires_at", nullable = false)
     private LocalDateTime expiresAt;
-
 
     // 토큰 생성 시각
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     // 토큰 철회(무효화) 시각
-    // null이면 유효한 토큰, 값이 있으면 무효화된 토큰
-    // 로그아웃이나 보안 문제 시 설정
     @Column(name = "revoked_at")
     private LocalDateTime revokedAt;
-
 
     @Builder
     public AuthRefreshToken(User user, String tokenValue, LocalDateTime expiresAt) {
@@ -63,9 +54,14 @@ public class AuthRefreshToken {
         this.revokedAt = null;  // 철회 상태 초기화
     }
 
-     // 토큰 무효화, 로그아웃 시 호출하여 재발급 방지
+    // 토큰 무효화 (로그아웃 시 호출)
     public void revoke() {
         this.revokedAt = LocalDateTime.now();
+    }
+
+    // 로그아웃 시 사용 (특정 시각 지정)
+    public void revoke(LocalDateTime revokedAt) {
+        this.revokedAt = revokedAt;
     }
 
     // 토큰 유효성 검증

--- a/src/main/java/com/thunder11/scuad/auth/repository/AuthRefreshTokenRepository.java
+++ b/src/main/java/com/thunder11/scuad/auth/repository/AuthRefreshTokenRepository.java
@@ -29,4 +29,8 @@ public interface AuthRefreshTokenRepository extends JpaRepository<AuthRefreshTok
     // 만료된 토큰 삭제용 조회
     // 배치 작업에서 사용
     List<AuthRefreshToken> findByExpiresAtBefore(LocalDateTime now);
+
+    // 특정 사용자의 모든 유효한 Refresh Token 조회
+    // 로그아웃 시 전체 디바이스 무효화에 사용
+    List<AuthRefreshToken> findByUser_UserIdAndRevokedAtIsNull(Long userId);
 }

--- a/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
+++ b/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.thunder11.scuad.auth.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import com.thunder11.scuad.auth.domain.*;
@@ -278,5 +279,30 @@ public class AuthService {
                 newRefreshToken,  // 클라이언트에는 원본 토큰 전달 (쿠키용)
                 jwtProperties.getAccessTokenExpiration() / 1000
         );
+    }
+
+    // 전체 디바이스 로그아웃
+    // 해당 사용자의 모든 유효한 Refresh Token을 철회
+    @Transactional
+    public void logoutAllDevices(Long userId) {
+        log.info("전체 디바이스 로그아웃 시작: userId={}", userId);
+
+        // 해당 사용자의 모든 유효한 토큰 조회
+        List<AuthRefreshToken> validTokens = refreshTokenRepository
+                .findByUser_UserIdAndRevokedAtIsNull(userId);
+
+        if (validTokens.isEmpty()) {
+            log.warn("로그아웃할 유효한 토큰이 없음: userId={}", userId);
+            return;
+        }
+
+        // 모든 토큰 철회
+        LocalDateTime now = LocalDateTime.now();
+        validTokens.forEach(token -> token.revoke(now));
+
+        refreshTokenRepository.saveAll(validTokens);
+
+        log.info("전체 디바이스 로그아웃 완료: userId={}, 철회된 토큰 수={}",
+                userId, validTokens.size());
     }
 }


### PR DESCRIPTION
- POST /api/v1/auth/logout 엔드포인트 추가
- 사용자의 모든 유효한 Refresh Token 철회 기능 구현
- Refresh Token 쿠키 즉시 만료 처리
- AuthRefreshTokenRepository에 효율적인 쿼리 메서드 추가
- 204 No Content 응답으로 로그아웃 완료 처리