### PR TITLE
fix : 파일메세지 전송 문제 해결

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
@@ -61,6 +61,7 @@ public class ChatMessageService {
                         .fileName(info.fileName)
                         .fileSize(info.fileSize)
                         .contentType(info.contentType)
+                        .fileUrl(null)
                         .build();
             }
         }


### PR DESCRIPTION
- ChatMessageResponse에 fileUrl 필드가 있는데, ChatMessageService에서 fileUrl을 설정하지 않던 문제 해결