### PR TITLE
fix : 파일 채팅 메세지 전송 문제 해결

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
@@ -283,19 +283,24 @@ public class ChatMessageService {
         nicknameMap.put(userId, senderNickname);
 
         // 10. 파일 정보 조회
-        // FIXME: ClassCastException 방지를 위해 Object[] 타입 명시 필요
+        // findFileInfosByIds(List)를 재사용하여 ClassCastException 방지
+        // 이유: 단건 Optional<Object[]> 쿼리는 JPQL 다중 컬럼 반환 시 Object[][] 로 감싸져
+        //       arr[0]이 Long이 아닌 Object[]가 되어 ClassCastException 발생.
+        //       getMessages()에서 이미 검증된 List<Object[]> 방식으로 통일.
         Map<Long, FileInfo> fileInfoMap = new HashMap<>();
         if (savedMessage.getFileId() != null) {
-            Optional<Object[]> fileInfoOpt = fileObjectRepository.findFileInfoById(savedMessage.getFileId());
-            if (fileInfoOpt.isPresent()) {
-                Object[] arr = fileInfoOpt.get();
+            List<Object[]> fileInfos = fileObjectRepository.findFileInfosByIds(
+                    java.util.List.of(savedMessage.getFileId())
+            );
+            if (!fileInfos.isEmpty()) {
+                Object[] arr = fileInfos.get(0);
                 FileInfo info = new FileInfo(
                         (Long) arr[0],      // fileId
                         (String) arr[1],    // fileName
                         (String) arr[2],    // contentType
                         (Long) arr[3]       // fileSize
                 );
-                fileInfoMap.put(info.fileId, info);
+                fileInfoMap.put(info.fileId(), info);
             }
         }
 


### PR DESCRIPTION
# [Fix] 채팅 파일 메시지 전송 시 ClassCastException 수정

## 개요

채팅방에서 파일 메시지(`messageType=FILE`) 전송 시 500 Internal Server Error가 발생하는 버그를 수정합니다.

---

## 문제 원인

`ChatMessageService.sendMessage()` 내부에서 파일 정보를 조회할 때 `FileObjectRepository.findFileInfoById()`를 사용하였습니다.

해당 메서드는 `Optional<Object[]>`를 반환하도록 선언되어 있으나, **JPQL에서 다중 컬럼을 SELECT할 경우 JPA는 실제로 `Object[][]`(배열의 배열) 형태로 결과를 반환**합니다.

이로 인해 `arr[0]`을 `Long`으로 캐스팅하는 시점에서 `ClassCastException`이 발생하였습니다.

```
java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class java.lang.Long
    at ChatMessageService.sendMessage(ChatMessageService.java:292)
```

---

## 해결 방법

`sendMessage()`에서 단건 조회에 사용하던 `findFileInfoById()`를 제거하고, `getMessages()`에서 이미 검증된 `findFileInfosByIds(List<Long>)`를 재사용하도록 수정하였습니다.

`List<Object[]>` 방식은 JPQL 다중 컬럼 반환 시에도 `Object[]` 타입이 안정적으로 보장되어 ClassCastException이 발생하지 않습니다.

---

## 변경 파일

- `src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java`

---

## 변경 내용

### Before

```java
// FIXME: ClassCastException 방지를 위해 Object[] 타입 명시 필요
Map<Long, FileInfo> fileInfoMap = new HashMap<>();
if (savedMessage.getFileId() != null) {
    Optional<Object[]> fileInfoOpt = fileObjectRepository.findFileInfoById(savedMessage.getFileId());
    if (fileInfoOpt.isPresent()) {
        Object[] arr = fileInfoOpt.get();
        FileInfo info = new FileInfo(
                (Long) arr[0],      // fileId
                (String) arr[1],    // fileName
                (String) arr[2],    // contentType
                (Long) arr[3]       // fileSize
        );
        fileInfoMap.put(info.fileId, info);
    }
}
```

### After

```java
// findFileInfosByIds(List)를 재사용하여 ClassCastException 방지
// 이유: 단건 Optional<Object[]> 쿼리는 JPQL 다중 컬럼 반환 시 Object[][] 로 감싸져
//       arr[0]이 Long이 아닌 Object[]가 되어 ClassCastException 발생.
//       getMessages()에서 이미 검증된 List<Object[]> 방식으로 통일.
Map<Long, FileInfo> fileInfoMap = new HashMap<>();
if (savedMessage.getFileId() != null) {
    List<Object[]> fileInfos = fileObjectRepository.findFileInfosByIds(
            java.util.List.of(savedMessage.getFileId())
    );
    if (!fileInfos.isEmpty()) {
        Object[] arr = fileInfos.get(0);
        FileInfo info = new FileInfo(
                (Long) arr[0],      // fileId
                (String) arr[1],    // fileName
                (String) arr[2],    // contentType
                (Long) arr[3]       // fileSize
        );
        fileInfoMap.put(info.fileId(), info);
    }
}
```

---