### PR TITLE
fix : 1인 1공고 1채팅방 로직 수정

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomRepository.java
@@ -21,7 +21,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         long countByJobMasterIdAndStatusAndDeletedAtIsNull(Long jobMasterId, RoomStatus status);
 
         // 방장이 특정 공고에 이미 방을 만들었는지 확인
-        boolean existsByJobMasterIdAndCreatedByAndDeletedAtIsNull(Long jobMasterId, Long createdBy);
+        boolean existsByJobMasterIdAndCreatedByAndDeletedAtIsNullAndStatus(
+                Long jobMasterId, Long createdBy, RoomStatus status);
 
         // 공고별 채팅방 목록 조회 (커서 기반 페이징)
         @Query("SELECT cr FROM ChatRoom cr " +

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -290,8 +290,9 @@ public class ChatRoomService {
         }
 
         // 6. 중복 방 생성 확인
-        if (chatRoomRepository.existsByJobMasterIdAndCreatedByAndDeletedAtIsNull(jobMasterId, userId)) {
-            log.warn("이미 해당 공고에 생성한 채팅방이 있습니다: jobMasterId={}, userId={}", jobMasterId, userId);
+        if (chatRoomRepository.existsByJobMasterIdAndCreatedByAndDeletedAtIsNullAndStatus(
+                jobMasterId, userId, RoomStatus.ACTIVE)) {
+            log.warn("이미 해당 공고에 활성 채팅방이 있습니다: jobMasterId={}, userId={}", jobMasterId, userId);
             throw new ApiException(ErrorCode.CHAT_ROOM_ALREADY_EXISTS);
         }
 


### PR DESCRIPTION
<html><head></head><body><h1>[Fix] 채팅방 생성 시 CLOSED 상태 방으로 인한 중복 생성 차단 버그 수정</h1>
<p>closes #{{이슈번호}}</p>
<hr>
<h2>트러블 슈팅</h2>
<h3>문제 상황</h3>
<p>채팅방 방장이 채팅방을 종료한 후 동일한 공고에 새 채팅방을 생성하려 하면
<strong>"이미 해당 공고에 생성한 채팅방이 있습니다"</strong> 에러가 발생하며 생성이 차단됨.</p>
<h3>원인 분석</h3>
<p><code>createChatRoom()</code> 내 중복 방 생성 확인 로직이 <code>deletedAt IS NULL</code> 조건만으로
기존 채팅방 존재 여부를 판단하고 있었음.</p>
<pre><code class="language-java">// 기존 코드
if (chatRoomRepository.existsByJobMasterIdAndCreatedByAndDeletedAtIsNull(jobMasterId, userId)) {
    throw new ApiException(ErrorCode.CHAT_ROOM_ALREADY_EXISTS);
}
</code></pre>
<p><code>closeChatRoom()</code>은 채팅방 <code>status</code>를 <code>CLOSED</code>로 변경할 뿐, <code>deleted_at</code>은 설정하지 않음.
따라서 CLOSED된 방도 <code>deletedAt IS NULL</code> 조건에 걸려 새 채팅방 생성을 막는 상황이 발생.</p>
<pre><code>채팅방 생성 → 채팅방 종료(CLOSED, deletedAt=null) → 새 채팅방 생성 시도
    → deletedAt IS NULL 조건에 CLOSED된 방이 걸림 → 생성 차단 버그
</code></pre>
<h3>해결 방법</h3>
<p>중복 체크 조건에 <code>status = ACTIVE</code>를 추가하여 <strong>ACTIVE 상태인 방만 중복으로 판단</strong>하도록 수정.
CLOSED된 방은 실질적으로 종료된 방이므로 새 채팅방 생성을 막아서는 안 됨.</p>
<hr>
<h2>작업 내용</h2>
<h3>커밋 1: 채팅방 생성 시 중복 체크 조건에 ACTIVE 상태 추가</h3>
<ul>
<li>
<p><strong>ChatRoomRepository 메서드 수정</strong></p>
<ul>
<li><code>existsByJobMasterIdAndCreatedByAndDeletedAtIsNull()</code>
→ <code>existsByJobMasterIdAndCreatedByAndDeletedAtIsNullAndStatus()</code> 로 변경</li>
<li>ACTIVE 상태인 방만 중복으로 판단하도록 조건 추가</li>
</ul>
</li>
<li>
<p><strong>ChatRoomService <code>createChatRoom()</code> 호출부 수정</strong></p>
<ul>
<li>수정된 Repository 메서드 호출 시 <code>RoomStatus.ACTIVE</code> 파라미터 전달</li>
<li>로그 메시지도 "활성 채팅방"으로 명확하게 수정</li>
</ul>
</li>
</ul>
<hr>
<h2>설계 의도</h2>
<h3>CLOSED 상태 방을 중복으로 보지 않는 이유</h3>
<p>채팅방 종료는 방장이 의도적으로 해당 채팅을 마무리한 것으로,
이후 같은 공고에 새 채팅방을 만드는 것은 정상적인 사용 흐름입니다.</p>
<p>중복을 막아야 하는 경우는 <strong>현재 진행 중인(ACTIVE) 채팅방이 있을 때</strong>이며,
종료된 방까지 중복으로 판단하는 것은 지나친 제약입니다.</p>
<pre><code>ACTIVE 방 존재 → 새 채팅방 생성 차단 (정상)
CLOSED 방만 존재 → 새 채팅방 생성 허용 (이번 수정)
</code></pre>
<hr>
<h2>변경 파일</h2>

파일 | 변경 내용
-- | --
ChatRoomRepository.java | 중복 체크 메서드에 status 조건 추가
ChatRoomService.java | 수정된 메서드 호출 및 로그 메시지 수정


<hr>
<h2>테스트 시나리오</h2>
<p><strong>시나리오 1: 정상 케이스 (버그 수정 확인)</strong></p>
<pre><code>Given: 방장이 공고 A에 채팅방을 생성 후 종료(CLOSED)
When: 동일한 공고 A에 새 채팅방 생성 시도
Then: 200 OK, 새 채팅방 생성 성공
</code></pre>
<p><strong>시나리오 2: 기존 정상 케이스 유지 확인</strong></p>
<pre><code>Given: 방장이 공고 A에 ACTIVE 상태인 채팅방이 존재
When: 동일한 공고 A에 새 채팅방 생성 시도
Then: 400 BAD_REQUEST, CHAT_ROOM_ALREADY_EXISTS
</code></pre></body></html>