### PR TITLE
fix : 방장 나가기 시도 시 에러 대신 채팅방 자동 종료 처리

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -497,10 +497,21 @@ public class ChatRoomService {
                 .findByChatRoomIdAndUserIdAndKickedAtIsNull(chatRoomId, userId)
                 .orElseThrow(() -> new ApiException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
 
-        // 3. 방장은 퇴장 불가 (방을 종료해야 함)
+        // 3. 방장인 경우 채팅방 종료 처리
+        // 수정 이유: 방장 입장에서 나가기와 종료하기는 동일한 결과이므로
+        //           나가기 시도 시 에러를 던지는 대신 채팅방을 자동 종료
         if (member.getRole() == MemberRole.HOST) {
-            log.warn("방장의 퇴장 시도: chatRoomId={}, userId={}", chatRoomId, userId);
-            throw new ApiException(ErrorCode.CHAT_ROOM_HOST_ONLY);
+            log.info("방장의 나가기 시도 → 채팅방 자동 종료: chatRoomId={}, userId={}", chatRoomId, userId);
+            chatRoom.close();
+            chatRoomRepository.save(chatRoom);
+
+            ChatMessage systemMessage = ChatMessage.createSystemMessage(
+                    chatRoomId,
+                    "채팅방이 종료되었습니다."
+            );
+            chatMessageRepository.save(systemMessage);
+            log.info("방장 나가기로 인한 채팅방 종료 완료: chatRoomId={}", chatRoomId);
+            return;
         }
 
         // 4. 닉네임 조회 (삭제 전에 조회해야 함)
@@ -517,7 +528,6 @@ public class ChatRoomService {
                 chatRoomId,
                 nickname + "님이 퇴장했습니다."
         );
-
         chatMessageRepository.save(systemMessage);
         log.info("퇴장 시스템 메시지 생성 완료: chatRoomId={}, userId={}", chatRoomId, userId);
     }


### PR DESCRIPTION
<html><head></head><body><h1>[Fix] 방장 나가기 시도 시 에러 대신 채팅방 자동 종료 처리</h1>
<p>closes #{{이슈번호}}</p>
<hr>
<h2>트러블 슈팅</h2>
<h3>문제 상황</h3>
<p>채팅방 방장이 <strong>나가기</strong> 버튼을 클릭하면 오류가 발생하며 정상 동작하지 않음.
반면 <strong>채팅방 종료하기</strong> 버튼은 정상 동작함.</p>
<h3>원인 분석</h3>
<p><code>leaveChatRoom()</code>에서 방장이 나가기를 시도하면 <code>CHAT_ROOM_HOST_ONLY</code> 에러를 던지도록 구현되어 있었음.</p>
<pre><code class="language-java">// 기존 코드
if (member.getRole() == MemberRole.HOST) {
    throw new ApiException(ErrorCode.CHAT_ROOM_HOST_ONLY);
}
</code></pre>
<p>방장은 나가기 대신 종료하기를 사용해야 한다는 의도였으나,
프론트에서 <code>CHAT_ROOM_HOST_ONLY</code> 에러를 "오류"로만 표시하여 사용자에게 혼란을 줌.</p>
<p>또한 사용자 입장에서 방장의 <strong>나가기</strong>와 <strong>종료하기</strong>는 동일한 결과(채팅방 종료)이므로
굳이 두 가지 동작을 구분할 필요가 없음.</p>
<h3>해결 방법</h3>
<p>방장이 나가기를 시도할 경우 에러를 던지는 대신 <strong>채팅방을 자동 종료</strong> 처리하도록 수정.
종료 시 기존 <code>closeChatRoom()</code>과 동일하게 <code>status = CLOSED</code> 처리 및 시스템 메시지 생성.</p>
<hr>
<h2>작업 내용</h2>
<h3>커밋 1: 방장 나가기 시도 시 채팅방 자동 종료 처리</h3>
<ul>
<li><strong>ChatRoomService <code>leaveChatRoom()</code> 수정</strong>
<ul>
<li>기존: 방장 나가기 시도 시 <code>CHAT_ROOM_HOST_ONLY</code> 에러 반환</li>
<li>수정: 방장 나가기 시도 시 채팅방 <code>status = CLOSED</code> 처리 후 return</li>
<li>종료 시 <code>"채팅방이 종료되었습니다."</code> 시스템 메시지 생성</li>
<li>일반 멤버 나가기 로직은 기존과 동일하게 유지</li>
</ul>
</li>
</ul>
<hr>
<h2>설계 의도</h2>
<h3>방장 나가기를 자동 종료로 처리한 이유</h3>
<p>방장이 채팅방을 나간다는 것은 더 이상 채팅방을 운영하지 않겠다는 의미입니다.
이 경우 사용자에게 에러를 보여주는 것보다 <strong>의도에 맞게 채팅방을 종료하는 것</strong>이 UX상 자연스럽습니다.</p>
<pre><code>방장 나가기 클릭
    ↓
기존: CHAT_ROOM_HOST_ONLY 에러 → 사용자에게 "오류" 표시 (혼란)
수정: 채팅방 자동 종료(CLOSED) → "채팅방이 종료되었습니다." 시스템 메시지
</code></pre>
<h3>기존 종료하기 버튼과의 관계</h3>
<p><code>closeChatRoom()</code>과 <code>leaveChatRoom()</code>(방장 케이스)의 결과가 동일합니다.
두 진입점이 같은 결과를 내도록 통일하여 일관성을 확보했습니다.</p>
<hr>
<h2>변경 파일</h2>

파일 | 변경 내용
-- | --
ChatRoomService.java | leaveChatRoom() 방장 케이스 자동 종료 처리로 수정


<hr>
<h2>테스트 시나리오</h2>
<p><strong>시나리오 1: 방장 나가기 (버그 수정 확인)</strong></p>
<pre><code>Given: 방장이 ACTIVE 상태인 채팅방에 참여 중
When: 방장이 나가기 버튼 클릭 (DELETE /api/v1/chat-rooms/{chatRoomId}/members/me)
Then: 200 OK, 채팅방 status = CLOSED
      채팅 메시지에 "채팅방이 종료되었습니다." 시스템 메시지 생성
</code></pre>
<p><strong>시나리오 2: 일반 멤버 나가기 (기존 정상 케이스 유지 확인)</strong></p>
<pre><code>Given: 일반 멤버가 ACTIVE 상태인 채팅방에 참여 중
When: 일반 멤버가 나가기 버튼 클릭
Then: 200 OK, 멤버 삭제
      채팅 메시지에 "OO님이 퇴장했습니다." 시스템 메시지 생성
</code></pre>
<p><strong>시나리오 3: 종료하기 버튼 (기존 정상 케이스 유지 확인)</strong></p>
<pre><code>Given: 방장이 ACTIVE 상태인 채팅방에 참여 중
When: 방장이 종료하기 버튼 클릭 (PATCH /api/v1/chat-rooms/{chatRoomId}/close)
Then: 200 OK, 채팅방 status = CLOSED
      채팅 메시지에 "채팅방이 종료되었습니다." 시스템 메시지 생성
</code></pre></body></html>