### PR TITLE
fix : 채팅 메시지 시간 한국 시간(KST) 기준으로 수정

### DIFF
--- a/src/main/java/com/thunder11/scuad/ScuadApplication.java
+++ b/src/main/java/com/thunder11/scuad/ScuadApplication.java
@@ -3,10 +3,13 @@ package com.thunder11.scuad;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class ScuadApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(ScuadApplication.class, args);
 	}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,8 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+        jdbc:
+          time_zone: Asia/Seoul
 
   security:
     oauth2:


### PR DESCRIPTION
<html><head></head><body><h1>[Fix] 채팅 메시지 시간 한국 시간(KST) 기준으로 수정</h1>
<p>closes #{{이슈번호}}</p>
<hr>
<h2>트러블 슈팅</h2>
<h3>문제 상황</h3>
<p>채팅방 내 메시지 전송 시간이 실제 한국 시간(KST)이 아닌
UTC 기준으로 표시되어 <strong>9시간 느리게</strong> 나타남.</p>
<h3>원인 분석</h3>
<p>두 가지 설정이 누락되어 있었음.</p>
<p><strong>1. JVM 타임존 미설정</strong>
서버의 기본 타임존이 UTC이고, <code>ScuadApplication</code>에서 JVM 타임존을 별도로 설정하지 않아
애플리케이션 전체가 UTC 기준으로 시간을 처리함.</p>
<p><strong>2. Hibernate <code>jdbc.time_zone</code> 미설정</strong>
<code>application.yml</code>의 DB URL에는 <code>serverTimezone=Asia/Seoul</code>이 설정되어 있었으나,
Hibernate가 DB에 시간을 저장/조회할 때 사용하는 타임존이 별도로 설정되어 있지 않아
UTC 기준으로 처리됨.</p>
<pre><code>DB URL: serverTimezone=Asia/Seoul  ← 설정되어 있음
JVM 타임존: UTC (서버 기본값)       ← 누락
Hibernate jdbc.time_zone: 미설정    ← 누락

→ 시간 저장/조회 시 UTC 기준으로 처리되어 KST와 9시간 차이 발생
</code></pre>
<h3>해결 방법</h3>
<p>두 가지를 함께 수정하여 애플리케이션 전체의 타임존을 <code>Asia/Seoul</code>로 통일.</p>
<hr>
<h2>작업 내용</h2>
<h3>커밋 1: JVM 타임존 및 Hibernate 타임존 Asia/Seoul 설정 추가</h3>
<ul>
<li>
<p><strong>ScuadApplication.java 수정</strong></p>
<ul>
<li><code>main()</code> 최상단에 <code>TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))</code> 추가</li>
<li>애플리케이션 시작 시점에 JVM 타임존을 Asia/Seoul로 고정</li>
</ul>
</li>
<li>
<p><strong>application.yml 수정</strong></p>
<ul>
<li><code>spring.jpa.properties.hibernate.jdbc.time_zone: Asia/Seoul</code> 추가</li>
<li>Hibernate가 DB에 시간을 저장/조회할 때 Asia/Seoul 기준으로 처리</li>
<li><code>application.yml</code>은 공통 베이스 설정이므로 local, dev, prod 모든 환경에 자동 적용</li>
</ul>
</li>
</ul>
<hr>
<h2>설계 의도</h2>
<h3>application.yml에만 추가한 이유</h3>
<p>Spring Boot의 설정 파일 구조는 아래와 같이 동작합니다.</p>
<pre><code>application.yml          ← 공통 베이스 (모든 환경 적용)
application-local.yml    ← local 환경에서 덮어씀
application-dev.yml      ← dev 환경에서 덮어씀
</code></pre>
<p><code>hibernate.jdbc.time_zone</code>은 환경에 관계없이 항상 동일하게 적용되어야 하는 설정이므로
공통 베이스인 <code>application.yml</code>에만 추가하면 세 환경 모두 자동으로 적용됩니다.</p>
<h3>JVM 타임존과 Hibernate 타임존을 함께 설정한 이유</h3>
<p>둘 중 하나만 설정할 경우 일부 시간 처리에서 여전히 UTC가 사용될 수 있습니다.
두 설정을 함께 적용하여 애플리케이션 전체의 타임존을 완전히 통일했습니다.</p>
<hr>
<h2>변경 파일</h2>

파일 | 변경 내용
-- | --
ScuadApplication.java | JVM 타임존 Asia/Seoul 설정 추가
application.yml | hibernate.jdbc.time_zone Asia/Seoul 설정 추가


<hr>
<h2>테스트 시나리오</h2>
<p><strong>시나리오 1: 메시지 전송 시간 확인 (버그 수정 확인)</strong></p>
<pre><code>Given: 서버 배포 후 채팅방 입장
When: 현재 시간 오전 10:00 KST에 메시지 전송
Then: 메시지 옆 시간이 오전 10:00로 표시됨
      (기존: 오전 01:00으로 표시)
</code></pre>
<p><strong>시나리오 2: 시스템 메시지 시간 확인</strong></p>
<pre><code>Given: 서버 배포 후 채팅방 입장
When: 현재 시간 오전 10:00 KST에 채팅방 입장
Then: "OO님이 입장했습니다." 시스템 메시지 시간이 오전 10:00로 표시됨
</code></pre></body></html>