### PR TITLE
refactor: 의도된 예외(2xx, 4xx)에 대한 불필요한 Error 로그 출력 개선

### DIFF
--- a/src/main/java/com/thunder11/scuad/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/thunder11/scuad/common/exception/GlobalExceptionHandler.java
@@ -23,9 +23,13 @@ public class GlobalExceptionHandler {
 
         @ExceptionHandler(ApiException.class)
         public ResponseEntity<ApiResponse<Object>> handleApiException(ApiException e) {
-                log.error("handleApiException: ", e);
-
                 ErrorCode ec = e.getErrorCode();
+
+                if (ec.getStatus().is5xxServerError()) {
+                        log.error("handleApiException (Server Error): ", e);
+                } else {
+                        log.warn("handleApiException (Client/Info): [{}] {}", ec.getCode(), e.getMessage());
+                }
 
                 return ResponseEntity.status(ec.getStatus())
                                 .body(ApiResponse.of(


### PR DESCRIPTION
- 기존에는 비즈니스 로직(ApiException)에서 202 Accepted 등의 상태를 반환할 때도 무조건 스택 트레이스를 포함한 Error 레벨 로그를 출력하여 진짜 서버 에러(500) 확인을 방해함
- ApiException 핸들링 시, 5xx 에러일 때만 log.error(스택 트레이스 포함)를 남기도록 수정
- 그 외 클라이언트/정보성 상태 코드 예외는 log.warn을 사용하여 한 줄 메시지로만 출력되도록 처리하여 로그 가독성 개선