### PR TITLE
perf: 채용 공고 목록 조회 커서 토큰화(HMAC) 및 N+1 병목 해결

### DIFF
--- a/src/main/java/com/thunder11/scuad/common/util/CursorTokenUtil.java
+++ b/src/main/java/com/thunder11/scuad/common/util/CursorTokenUtil.java
@@ -1,0 +1,91 @@
+package com.thunder11.scuad.common.util;
+
+import org.springframework.beans.factory.annotation.Value;import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.thunder11.scuad.jobposting.domain.type.JobStatus;
+
+@Component
+public class CursorTokenUtil {
+
+    @Value("${jwt.secret:default-secret-key-must-be-changed-in-production}")
+    private String secretKey;
+
+    private static final String HMAC_ALGO = "HmacSHA256";
+    private static final String VERSION = "v1";
+
+    public String createToken(Long id, LocalDate endDate, JobStatus status) {
+        if (id == null || endDate == null || status == null) {
+            return null;
+        }
+        long epochMills = endDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        String payload = String.format("%s|%d|%s|%s", VERSION, id, epochMills, status.name());
+        String signature = generateHmac(payload);
+        String rawToken = payload + ":" + signature;
+
+        return Base64.getEncoder().withoutPadding().encodeToString(rawToken.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public CursorData decodeToken(String token) {
+        if (token == null || token.isBlank()) {
+            return null;
+        }
+        try {
+            String decodedToken = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
+            String[] parts = decodedToken.split(":");
+            if (parts.length != 2) throw new IllegalArgumentException("커서 토큰 형식이 잘못되었습니다.");
+            String payload = parts[0];
+            String signature = parts[1];
+
+            if (!generateHmac(payload).equals(signature)) {
+                throw new SecurityException("커서 토큰이 변조되었습니다.");
+            }
+            String[] dataParts = payload.split("\\|");
+            if ("v1".equals(dataParts[0])) {
+                long id = Long.parseLong(dataParts[1]);
+                long epochMillis = Long.parseLong(dataParts[2]);
+                LocalDate endDate = Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault()).toLocalDate();
+                JobStatus status = JobStatus.valueOf(dataParts[3]);
+
+                return new CursorData(id, endDate, status);
+            } else {
+                throw new IllegalArgumentException("지원하지 않는 버전입니다.");
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("타당하지 않은 커서 토큰입니다.");
+        }
+    }
+
+    private String generateHmac(String data) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGO);
+            SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), HMAC_ALGO);
+            mac.init(secretKeySpec);
+            byte[] bytes = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+
+            return Base64.getEncoder().withoutPadding().encodeToString(bytes);
+        } catch (Exception e) {
+            throw new RuntimeException("HMAC을 생성하는데 실패했습니다.",e);
+        }
+    }
+
+    public static class CursorData {
+        public Long cursorId;
+        public LocalDate cursorEndDate;
+        public JobStatus cursorStatus;
+
+        public CursorData(Long cursorId, LocalDate cursorEndDate, JobStatus cursorStatus) {
+            this.cursorId = cursorId;
+            this.cursorEndDate = cursorEndDate;
+            this.cursorStatus = cursorStatus;
+        }
+    }
+}

--- a/src/main/java/com/thunder11/scuad/jobposting/dto/request/JobPostingSearchCondition.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/dto/request/JobPostingSearchCondition.java
@@ -5,7 +5,7 @@ import lombok.Data;
 @Data
 public class JobPostingSearchCondition {
 
-    private Long cursor;
+    private String cursor;
     private Integer size = 20;
     private String keyword;
     private String status;

--- a/src/main/java/com/thunder11/scuad/jobposting/repository/JobMasterRepositoryCustom.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/repository/JobMasterRepositoryCustom.java
@@ -2,9 +2,10 @@ package com.thunder11.scuad.jobposting.repository;
 
 import java.util.List;
 
+import com.thunder11.scuad.common.util.CursorTokenUtil;
 import com.thunder11.scuad.jobposting.domain.JobMaster;
 import com.thunder11.scuad.jobposting.dto.request.JobPostingSearchCondition;
 
 public interface JobMasterRepositoryCustom {
-    List<JobMaster> searchJobPostings(JobPostingSearchCondition condition);
+    List<JobMaster> searchJobPostings(JobPostingSearchCondition condition, CursorTokenUtil.CursorData cursorData);
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/repository/JobMasterRepositoryImpl.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/repository/JobMasterRepositoryImpl.java
@@ -14,7 +14,6 @@ import org.springframework.util.StringUtils;
 
 import lombok.RequiredArgsConstructor;
 
-import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -24,6 +23,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.thunder11.scuad.jobposting.domain.JobMaster;
 import com.thunder11.scuad.jobposting.domain.type.JobStatus;
 import com.thunder11.scuad.jobposting.dto.request.JobPostingSearchCondition;
+import com.thunder11.scuad.common.util.CursorTokenUtil;
 
 @RequiredArgsConstructor
 public class JobMasterRepositoryImpl implements JobMasterRepositoryCustom {
@@ -31,14 +31,14 @@ public class JobMasterRepositoryImpl implements JobMasterRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<JobMaster> searchJobPostings(JobPostingSearchCondition condition) {
+    public List<JobMaster> searchJobPostings(JobPostingSearchCondition condition, CursorTokenUtil.CursorData cursorData) {
 
         List<Long> ids = queryFactory
                 .select(jobMaster.id)
                 .from(jobMaster)
                 .join(jobMaster.company, company)
                 .where(
-                        cursorCondition(condition.getCursor(), condition.getSort()),
+                        cursorCondition(cursorData, condition.getSort()),
                         eqStatus(condition.getStatus()),
                         containsKeyword(condition.getKeyword()))
                 .orderBy(getOrderSpecifier(condition.getSort()))
@@ -95,24 +95,16 @@ public class JobMasterRepositoryImpl implements JobMasterRepositoryCustom {
                 .otherwise(2);
     }
 
-    private BooleanExpression cursorCondition(Long cursorId, String sort) {
-        if (cursorId == null)
+    private BooleanExpression cursorCondition(CursorTokenUtil.CursorData cursorData, String sort) {
+        if (cursorData == null)
             return null;
 
+        Long cursorId = cursorData.cursorId;
+        LocalDate cursorEndDate = cursorData.cursorEndDate;
+        JobStatus cursorStatus = cursorData.cursorStatus;
+
         if ("DEADLINE_ASC".equalsIgnoreCase(sort)) {
-            Tuple cursorData = queryFactory
-                    .select(jobMaster.endDate, jobMaster.status)
-                    .from(jobMaster)
-                    .where(jobMaster.id.eq(cursorId))
-                    .fetchOne();
-
-            if (cursorData == null)
-                return null;
-
-            LocalDate cursorEndDate = cursorData.get(jobMaster.endDate);
-            JobStatus cursorStatus = cursorData.get(jobMaster.status);
             Integer cursorRank = (cursorStatus == JobStatus.OPEN) ? 1 : 2;
-
             NumberExpression<Integer> statusRank = getStatusRank();
 
             return statusRank.gt(cursorRank)
@@ -121,6 +113,6 @@ public class JobMasterRepositoryImpl implements JobMasterRepositoryCustom {
                             .and(jobMaster.id.lt(cursorId)));
         }
 
-        return jobMaster.id.lt(cursorId);
+        return jobMaster.id.lt(cursorData.cursorId);
     }
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/service/JobPostingManagementService.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/JobPostingManagementService.java
@@ -2,6 +2,7 @@ package com.thunder11.scuad.jobposting.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.EntityManager;
 
@@ -24,7 +25,7 @@ import com.thunder11.scuad.jobposting.dto.request.JobPostingSearchCondition;
 import com.thunder11.scuad.jobposting.dto.response.JobPostingListResponse;
 import com.thunder11.scuad.jobposting.repository.JobMasterSkillRepository;
 import com.thunder11.scuad.chat.repository.ChatRoomRepository;
-import java.util.stream.Collectors;
+import com.thunder11.scuad.common.util.CursorTokenUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -37,10 +38,16 @@ public class JobPostingManagementService {
     private final JobMasterSkillRepository jobMasterSkillRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final EntityManager entityManager;
+    private final CursorTokenUtil cursorTokenUtil;
 
     @Transactional(readOnly = true)
     public Map<String, Object> getJobPostings(JobPostingSearchCondition condition) {
-        List<JobMaster> masters = jobMasterRepository.searchJobPostings(condition);
+        CursorTokenUtil.CursorData cursorData = null;
+        if (condition.getCursor() != null && !condition.getCursor().isBlank() && !"-1".equals(condition.getCursor())) {
+            cursorData = cursorTokenUtil.decodeToken(condition.getCursor());
+        }
+
+        List<JobMaster> masters = jobMasterRepository.searchJobPostings(condition, cursorData);
 
         List<Long> masterIds = masters.stream().map(JobMaster::getId).toList();
         Map<Long, Long> chatCounts = chatRoomRepository.countActiveRoomsByJobMasterIds(masterIds)
@@ -53,13 +60,17 @@ public class JobPostingManagementService {
                 .map(m -> JobPostingListResponse.of(m, chatCounts.getOrDefault(m.getId(), 0L).intValue()))
                 .toList();
 
-        Long nextCursor = items.isEmpty() ? null : items.get(items.size() - 1).getId();
+        String nextCursorToken = "";
+        if (!masters.isEmpty()) {
+            JobMaster lastItem = masters.get(masters.size() - 1);
+            nextCursorToken = cursorTokenUtil.createToken(lastItem.getId(), lastItem.getEndDate(), lastItem.getStatus());
+        }
 
         boolean isLast = items.size() < condition.getSize();
 
         return Map.of(
                 "items", items,
-                "next_cursor", nextCursor != null ? nextCursor : -1L,
+                "next_cursor", nextCursorToken,
                 "last", isLast);
     }
 


### PR DESCRIPTION
- 기존 ID 기반 커서의 동적 정렬을 위한 사전 DB 단건 조회 쿼리(fetchOne) 제거
- cursorId, endDate, status 정보를 묶어 HMAC-SHA256 기반의 암호화 토큰 응답(CursorTokenUtil 구현)