### PR TITLE
fix: 액세스 토큰 만료 시 재로그인 요구 문제

### DIFF
--- a/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
+++ b/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
@@ -1,7 +1,13 @@
 package com.thunder11.scuad.common.config;
 
 import java.util.List;
+import java.util.Map;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,6 +38,38 @@ public class SecurityConfig {
 
     @Value("${app.frontend-url}")
     private String frontendUrl;
+
+    // 인증 실패 EntryPoint: 토큰이 없거나 만료된 경우 401 반환
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return (request, response, authException) -> {
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+            response.getWriter().write(
+                new ObjectMapper().writeValueAsString(Map.of(
+                    "status", 401,
+                    "code", "UNAUTHORIZED",
+                    "message", "인증이 필요합니다."
+                ))
+            );
+        };
+    }
+
+    // 권한 없음 핸들러: 인증은 됐지만 권한이 없는 경우 403 반환
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler() {
+        return (request, response, accessDeniedException) -> {
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+            response.getWriter().write(
+                new ObjectMapper().writeValueAsString(Map.of(
+                    "status", 403,
+                    "code", "FORBIDDEN",
+                    "message", "권한이 없습니다."
+                ))
+            );
+        };
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -69,7 +107,14 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
 
                 // JWT 인증 필터 추가 (UsernamePasswordAuthenticationFilter 앞에 배치)
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+                // 인증/인가 실패 시 커스텀 핸들러 등록
+                // - 401: 토큰 없음/만료 (프론트에서 자동 재발급 시도 트리거)
+                // - 403: 인증은 됐지만 권한 없음 (재발급 없이 에러 처리)
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint())
+                        .accessDeniedHandler(accessDeniedHandler()));
 
         return http.build();
     }


### PR DESCRIPTION
<html><head></head><body><h1>fix: 액세스 토큰 만료 시 재로그인 요구 문제</h1>
<hr>
<h2>🔍 문제 원인 분석</h2>
<h3>증상</h3>
<p>액세스 토큰이 만료되었을 때, 프론트엔드가 <strong>401</strong>을 기대하고 자동 재발급을 시도하지만 실제로 <strong>403</strong>이 내려와 재발급 로직이 동작하지 않고 강제 로그아웃이 발생했습니다.</p>
<h3>근본 원인</h3>
<p><code>SecurityConfig</code>에 <code>AuthenticationEntryPoint</code>가 설정되어 있지 않아, Spring Security의 <strong>기본 EntryPoint인 <code>Http403ForbiddenEntryPoint</code></strong> 가 동작했기 때문입니다.</p>
<p><strong>기존 요청 흐름:</strong></p>
<pre><code>액세스 토큰 만료
→ JwtAuthenticationFilter: ApiException(ACCESS_TOKEN_EXPIRED) catch
→ SecurityContextHolder.clearContext() (인증 정보 제거)
→ filterChain.doFilter() 계속 진행
→ Spring Security: 인증 정보 없는 요청 감지
→ 기본 Http403ForbiddenEntryPoint 동작 → 403 반환 ← 문제 지점
→ 프론트: 403이지만 토큰 만료 여부 불명확 → 재발급 실패 → 강제 로그아웃
</code></pre>
<h3>HTTP 상태코드 구분 기준 (HTTP 표준)</h3>

상태코드 | 의미 | 발생 시나리오 | 프론트 동작
-- | -- | -- | --
401 Unauthorized | 인증 없음 / 토큰 만료 | 액세스 토큰 없음, 만료 | 리프레시 토큰으로 자동 재발급 시도
403 Forbidden | 인증됐지만 권한 없음 | 비방장의 채팅방 종료 시도 등 | 재발급 없이 에러 메시지 처리

기존에는 두 경우 모두 `403`을 반환하고 있어, 프론트에서 **토큰 만료인지 권한 문제인지 구분이 불가능**했습니다.


---

##  변경 내용

### `SecurityConfig.java`

**추가 1: `AuthenticationEntryPoint` 빈 등록**

인증이 필요한 요청에서 SecurityContext가 비어있을 경우(토큰 없음/만료) `401`을 명시적으로 반환합니다.

```java
@Bean
public AuthenticationEntryPoint authenticationEntryPoint() {
    return (request, response, authException) -> {
        response.setStatus(HttpStatus.UNAUTHORIZED.value());
        response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
        response.getWriter().write(
            new ObjectMapper().writeValueAsString(Map.of(
                "status", 401,
                "code", "UNAUTHORIZED",
                "message", "인증이 필요합니다."
            ))
        );
    };
}
```

**추가 2: `AccessDeniedHandler` 빈 등록**

인증은 됐지만 권한이 없는 경우 `403`을 명시적으로 반환합니다.
(비즈니스 로직에서 `ApiException`으로 던지는 `403`과 역할 분리)

```java
@Bean
public AccessDeniedHandler accessDeniedHandler() {
    return (request, response, accessDeniedException) -> {
        response.setStatus(HttpStatus.FORBIDDEN.value());
        response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
        response.getWriter().write(
            new ObjectMapper().writeValueAsString(Map.of(
                "status", 403,
                "code", "FORBIDDEN",
                "message", "권한이 없습니다."
            ))
        );
    };
}
```

**추가 3: `exceptionHandling` 설정 등록**

두 핸들러를 Spring Security 필터 체인에 연결합니다.

```java
.exceptionHandling(ex -> ex
    .authenticationEntryPoint(authenticationEntryPoint())
    .accessDeniedHandler(accessDeniedHandler()))
```

### 수정 후 요청 흐름

```
액세스 토큰 만료
→ JwtAuthenticationFilter: ApiException(ACCESS_TOKEN_EXPIRED) catch
→ SecurityContextHolder.clearContext()
→ Spring Security: AuthenticationEntryPoint 동작
→ 401 반환 
→ 프론트: 401 감지 → 리프레시 토큰으로 자동 재발급 → 로그인 상태 유지
```

```
비방장이 채팅방 종료 시도
→ ChatRoomService: ApiException(CHAT_ROOM_HOST_ONLY) throw
→ GlobalExceptionHandler: 403 반환 
→ 프론트: 403 감지 → 재발급 없이 에러 메시지 처리
```

---

## 변경하지 않은 것 (이미 올바르게 구현됨)

| 파일 | 상태 | 이유 |
|---|---|---|
| `ErrorCode.java` | 유지 | `ACCESS_TOKEN_EXPIRED` → `401`, `CHAT_ROOM_HOST_ONLY` → `403` 이미 올바름 |
| `JwtProvider.java` | 유지 | 토큰 만료/위조 예외 구분 이미 정확함 |
| `JwtAuthenticationFilter.java` | 유지 | 비즈니스 로직 자체는 문제없음 |
| `GlobalExceptionHandler.java` | 유지 | `ApiException` 처리 흐름 정상 동작 |

---

<hr>
<h2>테스트 시나리오</h2>
<ul>
<li>[ ] 액세스 토큰 만료 상태에서 인증 필요 API 호출 → <code>401</code> 응답 확인</li>
<li>[ ] 리프레시 토큰으로 재발급 후 요청 재시도 → 정상 응답 확인</li>
<li>[ ] 비방장 계정으로 채팅방 종료 시도 → <code>403</code> 응답 확인 (재발급 시도 없음)</li>
<li>[ ] 토큰 없이 퍼블릭 API 호출 → 정상 응답 확인 (permitAll 경로)</li>
<li>[ ] 리프레시 토큰도 만료된 상태 → 재발급 실패 후 로그인 페이지 이동 확인</li>
</ul>
<hr>
<h2> 변경 파일</h2>
<pre><code>src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
</code></pre></body></html>