### PR TITLE
Feat/rabbitmq ai integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,9 @@ APP_FRONTEND_URL=http://localhost:3000
 
 #--- proxy ---                                                      
 JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=<proxy-ip> -Dhttp.proxyPort=3128 -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=localhost|127.*|10.*|*.amazonaws.com
+
+#--- RABBITMQ ---
+RABBITMQ_HOST=insert-your-rabbitmq-host (local: localhost)
+RABBITMQ_PORT=insert-your-rabbitmq-port (local: 5672)
+RABBITMQ_USERNAME=insert-your-rabbitmq-username (local: guest)
+RABBITMQ_PASSWORD=insert-your-rabbitmq-password (local: guest)

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.10.0'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
@@ -78,6 +79,7 @@ dependencies {
 	// database 마이그레이션 도구
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
 }
 

--- a/src/main/java/com/thunder11/scuad/api/internal/AiCallbackController.java
+++ b/src/main/java/com/thunder11/scuad/api/internal/AiCallbackController.java
@@ -1,0 +1,32 @@
+package com.thunder11.scuad.api.internal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.thunder11.scuad.infra.rabbitmq.dto.AiResponseMessage;
+import com.thunder11.scuad.jobposting.service.AiResultProcessingService;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/internal/ai")
+@RequiredArgsConstructor
+public class AiCallbackController {
+    private final AiResultProcessingService aiResultProcessingService;
+
+    @PostMapping("/callback")
+    public ResponseEntity<Void> handleAiResultCallback(
+            @RequestBody AiResponseMessage response) {
+        log.info("AI 분석 결과 콜백 수신 - evalJobId: {}, success: {}", response.getEvalJobId(), response.isSuccess());
+
+        aiResultProcessingService.processResult(response.getEvalJobId(), response);
+
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
+++ b/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
@@ -91,6 +91,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/job-postings/{jobMasterId}").permitAll()
                         // 헬스 체크는 퍼블릭 허용
                         .requestMatchers("/api/health").permitAll()
+                        // [로컬 전용] 부하 테스트용 토큰 발급 API
+                        .requestMatchers("/api/test/**").permitAll()
+                        .requestMatchers("/api/internal/**").permitAll()
                         // Actuator 엔드포인트 퍼블릭 허용
                         .requestMatchers("/actuator/**").permitAll()
                         // 채용공고 조회는 퍼블릭 허용 (임시)

--- a/src/main/java/com/thunder11/scuad/infra/rabbitmq/config/RabbitMQConfig.java
+++ b/src/main/java/com/thunder11/scuad/infra/rabbitmq/config/RabbitMQConfig.java
@@ -1,0 +1,77 @@
+package com.thunder11.scuad.infra.rabbitmq.config;
+
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+    public static final String EXCHANGE_NAME = "scuad.ai.exchange";
+    public static final String QUEUE_EVALUATION = "scuad.ai.queue.evaluation";
+    public static final String QUEUE_RESUME = "scuad.ai.queue.resume";
+    public static final String QUEUE_PORTFOLIO = "scuad.ai.queue.portfolio";
+    public static final String QUEUE_COMPARISON = "scuad.ai.queue.comparison";
+    public static final String QUEUE_JOBPOSTING = "scuad.ai.request.jobposting.queue";
+
+    @Bean
+    public DirectExchange aiExchange() {
+        return new DirectExchange(EXCHANGE_NAME);
+    }
+
+    @Bean
+    public Queue evaluationQueue() {
+        return new Queue(QUEUE_EVALUATION);
+    }
+    @Bean
+    public Queue resumeQueue() {
+        return new Queue(QUEUE_RESUME);
+    }
+    @Bean
+    public Queue portfolioQueue() {
+        return new Queue(QUEUE_PORTFOLIO);
+    }
+    @Bean
+    public Queue comparisonQueue() {
+        return new Queue(QUEUE_COMPARISON);
+    }
+    @Bean
+    public Queue jobpostingQueue() {
+        return new Queue(QUEUE_JOBPOSTING);
+    }
+
+
+    @Bean
+    public Binding bindEvaluation(Queue evaluationQueue, DirectExchange aiExchange) {
+        return BindingBuilder.bind(evaluationQueue).to(aiExchange).with(QUEUE_EVALUATION);
+    }
+
+    @Bean
+    public Binding bindResume(Queue resumeQueue, DirectExchange aiExchange) {
+        return BindingBuilder.bind(resumeQueue).to(aiExchange).with(QUEUE_RESUME);
+    }
+
+    @Bean
+    public Binding bindPortfolio(Queue portfolioQueue, DirectExchange aiExchange) {
+        return BindingBuilder.bind(portfolioQueue).to(aiExchange).with(QUEUE_PORTFOLIO);
+    }
+
+    @Bean
+    public Binding bindComparison(Queue comparisonQueue, DirectExchange aiExchange) {
+        return BindingBuilder.bind(comparisonQueue).to(aiExchange).with(QUEUE_COMPARISON);
+    }
+
+    @Bean
+    public Binding bindJobPosting(Queue jobpostingQueue, DirectExchange aiExchange) {
+        return BindingBuilder.bind(jobpostingQueue).to(aiExchange).with(QUEUE_JOBPOSTING);
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+}

--- a/src/main/java/com/thunder11/scuad/infra/rabbitmq/dto/AiRequestMessage.java
+++ b/src/main/java/com/thunder11/scuad/infra/rabbitmq/dto/AiRequestMessage.java
@@ -1,0 +1,16 @@
+package com.thunder11.scuad.infra.rabbitmq.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiRequestMessage {
+    private String evalJobId;
+    private String userId;
+    private String jobPostingId;
+}

--- a/src/main/java/com/thunder11/scuad/infra/rabbitmq/dto/AiResponseMessage.java
+++ b/src/main/java/com/thunder11/scuad/infra/rabbitmq/dto/AiResponseMessage.java
@@ -1,0 +1,21 @@
+package com.thunder11.scuad.infra.rabbitmq.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import com.thunder11.scuad.infra.ai.dto.response.AiApiResponse;
+
+@Getter
+@NoArgsConstructor
+public class AiResponseMessage {
+    @JsonProperty("eval_job_id")
+    private String evalJobId;
+
+    private boolean success;
+    private String timestamp;
+    private JsonNode data;
+    private AiApiResponse.AiError error;
+}

--- a/src/main/java/com/thunder11/scuad/jobposting/domain/type/AnalysisType.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/domain/type/AnalysisType.java
@@ -4,6 +4,5 @@ public enum AnalysisType {
     EVALUATION,
     RESUME,
     PORTFOLIO,
-    COMPARISON,
-    ALL
+    COMPARISON
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/service/AiEvaluationWorker.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/AiEvaluationWorker.java
@@ -1,10 +1,6 @@
 package com.thunder11.scuad.jobposting.service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.concurrent.CompletableFuture;
-
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
@@ -13,12 +9,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import com.thunder11.scuad.infra.ai.client.AiServiceClient;
-import com.thunder11.scuad.infra.ai.dto.request.AiEvaluationAnalysisRequest;
-import com.thunder11.scuad.infra.ai.dto.response.AiEvaluationResultResponse;
+import com.thunder11.scuad.infra.rabbitmq.config.RabbitMQConfig;
+import com.thunder11.scuad.infra.rabbitmq.dto.AiRequestMessage;
 import com.thunder11.scuad.jobposting.event.AiAnalysisCreateEvent;
-import com.thunder11.scuad.infra.ai.dto.response.AiPortfolioAnalysisResponse;
-import com.thunder11.scuad.infra.ai.dto.response.AiResumeAnalysisResponse;
 import com.thunder11.scuad.jobposting.domain.*;
 import com.thunder11.scuad.jobposting.repository.*;
 import com.thunder11.scuad.jobposting.domain.type.AnalysisType;
@@ -29,22 +22,13 @@ import com.thunder11.scuad.jobposting.domain.type.AnalysisType;
 public class AiEvaluationWorker {
 
     private final AiEvalJobRepository aiEvalJobRepository;
-    private final AiApplicationEvaluationRepository aiApplicationEvaluationRepository;
-    private final AiResumeAnalysisRepository aiResumeAnalysisRepository;
-    private final AiPortfolioAnalysisRepository aiPortfolioAnalysisRepository;
-    private final JobMasterRepository jobMasterRepository;
-    private final AiServiceClient aiServiceClient;
+    private final RabbitTemplate rabbitTemplate;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void processEvaluationAsync(AiAnalysisCreateEvent event) {
         log.info("AI 분석 작업시작: UserId={}, JobPostingId={}, Type={}",
                 event.getUserId(), event.getJobPostingId(), event.getAnalysisType());
-
-        if (event.getAnalysisType() == AnalysisType.ALL) {
-            processAllAnalysisPipelineAsync(event);
-            return;
-        }
 
         AiEvalJob aiEvalJob = aiEvalJobRepository
                 .findFirstByRequestedByUserIdAndJobApplicationJobMasterIdAndAnalysisTypeOrderByIdDesc(
@@ -53,207 +37,27 @@ public class AiEvaluationWorker {
                         event.getAnalysisType())
                 .orElseThrow(() -> new IllegalStateException("AI 분석 작업을 찾을 수 없습니다."));
 
-        try {
-            AiEvaluationAnalysisRequest request = AiEvaluationAnalysisRequest.builder()
-                    .userId(String.valueOf(event.getUserId()))
-                    .jobPostingId(String.valueOf(event.getJobPostingId()))
-                    .build();
-            switch (event.getAnalysisType()) {
-                case EVALUATION -> {
-                    AiEvaluationResultResponse result = aiServiceClient.analyzeEvaluation(request);
-                    saveEvaluationResult(aiEvalJob.getJobApplication(), result);
-                }
-                case RESUME -> {
-                    AiResumeAnalysisResponse result = aiServiceClient.analyzeResume(request);
-                    saveResumeResult(aiEvalJob.getJobApplication(), result);
-                }
-                case PORTFOLIO -> {
-                    AiPortfolioAnalysisResponse result = aiServiceClient.analyzePortfolio(request);
-                    savePortfolioResult(aiEvalJob.getJobApplication(), result);
-                }
-                default -> throw new IllegalStateException("지원하지 않는 분석 타입: " + event.getAnalysisType());
-            }
+        String routingKey = getQueueNameByType(event.getAnalysisType());
 
-            aiEvalJob.complete();
-            aiEvalJobRepository.save(aiEvalJob);
-            log.info("AI 분석 성공: JobId={},Type={}", aiEvalJob.getId(), event.getAnalysisType());
-        } catch (Exception e) {
-            log.error("AI Worker Failed: JobID={}, Msg={}", aiEvalJob.getId(), event.getAnalysisType(), e.getMessage());
-            aiEvalJob.fail(e.getMessage());
-            aiEvalJobRepository.save(aiEvalJob);
-        }
-    }
-
-    private void saveEvaluationResult(JobApplication application, AiEvaluationResultResponse result) {
-
-        List<EvaluationCriteria> criteria = result.getEvaluationCriteria() != null
-                ? result.getEvaluationCriteria().stream()
-                        .map(c -> new EvaluationCriteria(c.getName(), c.getDescription()))
-                        .collect(Collectors.toList())
-                : null;
-
-        List<EvaluationScore> evaluationScores = result.getCompetencyScores().stream()
-                .map(cs -> new EvaluationScore(cs.getName(), cs.getScore(), cs.getDescription()))
-                .collect(Collectors.toList());
-
-        if (criteria != null) {
-            JobMaster jobMaster = application.getJobMaster();
-            jobMaster.updateEvaluationCriteria(criteria);
-            jobMasterRepository.save(jobMaster);
-        }
-
-        Optional<AiApplicantEvaluation> existingOpt = aiApplicationEvaluationRepository
-                .findByJobApplicationId(application.getId());
-        if (existingOpt.isPresent()) {
-            AiApplicantEvaluation existing = existingOpt.get();
-            existing.updateEvaluation(
-                    result.getOverallScore(),
-                    result.getOneLineReview(),
-                    result.getFeedbackDetail(),
-                    evaluationScores);
-            aiApplicationEvaluationRepository.save(existing);
-            log.info("AI 평가 결과 업데이트 완료: ApplicationId={}", application.getId());
-        } else {
-            AiApplicantEvaluation evaluation = AiApplicantEvaluation.builder()
-                    .jobApplication(application)
-                    .overallScore(result.getOverallScore())
-                    .oneLineReview(result.getOneLineReview())
-                    .feedbackDetail(result.getFeedbackDetail())
-                    .comparisonScores(evaluationScores)
-                    .build();
-
-            aiApplicationEvaluationRepository.save(evaluation);
-            log.info("AI 평가 결과 신규 저장 완료: {}", application.getId());
-        }
-    }
-
-    private void saveResumeResult(JobApplication application, AiResumeAnalysisResponse result) {
-        aiResumeAnalysisRepository.findByJobApplicationId(application.getId())
-                .ifPresentOrElse(
-                        existing -> {
-                            existing.update(result.getAiAnalysisReport(), result.getJobFitScore(),
-                                    result.getExperienceClarityScore(), result.getReadabilityScore());
-                            aiResumeAnalysisRepository.save(existing);
-                            log.info("이력서 분석 결과 업데이트 완료: ApplicationId={}", application.getId());
-                        }, () -> {
-                            aiResumeAnalysisRepository.save(AiResumeAnalysis.builder()
-                                    .jobApplication(application)
-                                    .aiAnalysisReport(result.getAiAnalysisReport())
-                                    .jobFitScore(result.getJobFitScore())
-                                    .experienceClarityScore(result.getExperienceClarityScore())
-                                    .readabilityScore(result.getReadabilityScore())
-                                    .build());
-                            log.info("이력서 분석 결과 신규 저장 완료: ApplicationId={}", application.getId());
-                        });
-    }
-
-    private void savePortfolioResult(JobApplication application, AiPortfolioAnalysisResponse result) {
-        aiPortfolioAnalysisRepository.findByJobApplicationId(application.getId())
-                .ifPresentOrElse(
-                        existing -> {
-                            existing.update(result.getAiAnalysisReport(), result.getProblemSolvingScore(),
-                                    result.getContributionClarityScore(), result.getTechnicalDepthScore());
-                            aiPortfolioAnalysisRepository.save(existing);
-                            log.info("포트폴리오 분석 결과 업데이트 완료: ApplicationId={}", application.getId());
-                        },
-                        () -> {
-                            aiPortfolioAnalysisRepository.save(AiPortfolioAnalysis.builder()
-                                    .jobApplication(application)
-                                    .aiAnalysisReport(result.getAiAnalysisReport())
-                                    .problemSolvingScore(result.getProblemSolvingScore())
-                                    .contributionClarityScore(result.getContributionClarityScore())
-                                    .technicalDepthScore(result.getTechnicalDepthScore())
-                                    .build());
-                            log.info("포트폴리오 분석 결과 신규 저장 완료: ApplicationId={}", application.getId());
-                        });
-    }
-
-    private void processAllAnalysisPipelineAsync(AiAnalysisCreateEvent event) {
-        AiEvaluationAnalysisRequest request = AiEvaluationAnalysisRequest.builder()
+        AiRequestMessage message = AiRequestMessage.builder()
+                .evalJobId(String.valueOf(aiEvalJob.getId()))
                 .userId(String.valueOf(event.getUserId()))
                 .jobPostingId(String.valueOf(event.getJobPostingId()))
                 .build();
 
-        AiEvalJob evalJob = getLatestPendingJob(event, AnalysisType.EVALUATION);
-        AiEvalJob resumeJob = getLatestPendingJob(event, AnalysisType.RESUME);
-        Optional<AiEvalJob> portJobOpt = getOptionalLatestPendingJob(event, AnalysisType.PORTFOLIO);
+        aiEvalJob.startProcessing();
+        aiEvalJobRepository.save(aiEvalJob);
 
-        try {
-            if (evalJob != null) {
-                startProcessingJob(evalJob);
-
-                AiEvaluationResultResponse evalResult = aiServiceClient.analyzeEvaluation(request);
-                saveEvaluationResult(evalJob.getJobApplication(), evalResult);
-                completeJob(evalJob);
-            }
-        } catch (Exception e) {
-            log.error("통합 평가(파싱) 실패", e);
-            failJob(evalJob, e.getMessage());
-            failJob(resumeJob, "선행 파싱 완료 전 실패로 인한 이력서 분석 연쇄 중단");
-            portJobOpt.ifPresent(job -> failJob(job, "선행 파싱 완료 전 실패로 인한 포트폴리오 분석 연쇄 중단"));
-
-            return;
-        }
-
-        CompletableFuture<Void> resumeTask = CompletableFuture.runAsync(() -> {
-            try {
-                if (resumeJob != null) {
-                    startProcessingJob(resumeJob);
-                    AiResumeAnalysisResponse resResult = aiServiceClient.analyzeResume(request);
-                    saveResumeResult(resumeJob.getJobApplication(), resResult);
-                    completeJob(resumeJob);
-                }
-            } catch (Exception e) {
-                log.error("이력서 분석 실패", e);
-                failJob(resumeJob, e.getMessage());
-            }
-        });
-
-        CompletableFuture<Void> portTask = portJobOpt.map(portJob -> CompletableFuture.runAsync(() -> {
-            try {
-                startProcessingJob(portJob);
-                AiPortfolioAnalysisResponse portResult = aiServiceClient.analyzePortfolio(request);
-                savePortfolioResult(portJob.getJobApplication(), portResult);
-                completeJob(portJob);
-            } catch (Exception e) {
-                log.error("포트폴리오 분석 실패", e);
-                failJob(portJob, e.getMessage());
-            }
-            })).orElse(CompletableFuture.completedFuture(null));
-
-            CompletableFuture.allOf(resumeTask, portTask).join();
-            log.info("이력서 및 포트폴리오 분석 완료: JobPostingId={}", event.getJobPostingId());
-        }
-
-    private AiEvalJob getLatestPendingJob(AiAnalysisCreateEvent event, AnalysisType type) {
-        return aiEvalJobRepository.findFirstByRequestedByUserIdAndJobApplicationJobMasterIdAndAnalysisTypeOrderByIdDesc(
-                event.getUserId(), event.getJobPostingId(), type).orElse(null);
+        rabbitTemplate.convertAndSend(RabbitMQConfig.EXCHANGE_NAME, routingKey, message);
+        log.info("RabbitMQ 발송 완료 - Queue: {}, evalJobId: {}", routingKey, aiEvalJob.getId());
     }
 
-    private Optional<AiEvalJob> getOptionalLatestPendingJob(AiAnalysisCreateEvent event, AnalysisType type) {
-        return aiEvalJobRepository.findFirstByRequestedByUserIdAndJobApplicationJobMasterIdAndAnalysisTypeOrderByIdDesc(
-                event.getUserId(), event.getJobPostingId(), type);
-    }
-
-    private void startProcessingJob(AiEvalJob job) {
-        if (job != null) {
-            log.info("AI Worker Job ID: {} 작업을 시작합니다.", job.getId());
-            job.startProcessing();
-            aiEvalJobRepository.save(job);
-        }
-    }
-
-    private void completeJob(AiEvalJob job) {
-        if (job != null) {
-            job.complete();
-            aiEvalJobRepository.save(job);
-        }
-    }
-
-    private void failJob(AiEvalJob job, String message) {
-        if (job != null) {
-            job.fail(message);
-            aiEvalJobRepository.save(job);
-        }
+    private String getQueueNameByType(AnalysisType type) {
+        return switch (type) {
+            case EVALUATION -> RabbitMQConfig.QUEUE_EVALUATION;
+            case RESUME -> RabbitMQConfig.QUEUE_RESUME;
+            case PORTFOLIO -> RabbitMQConfig.QUEUE_PORTFOLIO;
+            case COMPARISON ->  RabbitMQConfig.QUEUE_COMPARISON;
+        };
     }
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/service/AiResultProcessingService.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/AiResultProcessingService.java
@@ -1,0 +1,154 @@
+package com.thunder11.scuad.jobposting.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import com.thunder11.scuad.infra.ai.dto.response.AiEvaluationResultResponse;
+import com.thunder11.scuad.infra.ai.dto.response.AiPortfolioAnalysisResponse;
+import com.thunder11.scuad.infra.ai.dto.response.AiResumeAnalysisResponse;
+import com.thunder11.scuad.infra.rabbitmq.dto.AiResponseMessage;
+import com.thunder11.scuad.jobposting.domain.*;
+import com.thunder11.scuad.jobposting.repository.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiResultProcessingService {
+    private final AiEvalJobRepository aiEvalJobRepository;
+    private final AiApplicationEvaluationRepository aiApplicationEvaluationRepository;
+    private final AiResumeAnalysisRepository aiResumeAnalysisRepository;
+    private final AiPortfolioAnalysisRepository aiPortfolioAnalysisRepository;
+    private final JobMasterRepository jobMasterRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void processResult(String evalJobId, AiResponseMessage response) {
+        AiEvalJob aiEvalJob = aiEvalJobRepository.findById(Long.parseLong(evalJobId))
+                .orElseThrow(() -> new IllegalArgumentException("AI 분석 작업을 찾을 수 없습니다. ID=" + evalJobId));
+
+        if (!response.isSuccess()) {
+            String errorMsg = (response.getError() != null) ? response.getError().getMessage() : "알 수 없는 오류";
+            log.error("AI 분석 실패 - evalJobId: {}, 사유: {}", evalJobId, errorMsg);
+            aiEvalJob.fail(errorMsg);
+            aiEvalJobRepository.save(aiEvalJob);
+            return;
+        }
+        try {
+            switch (aiEvalJob.getAnalysisType()) {
+                case EVALUATION -> {
+                    AiEvaluationResultResponse result = objectMapper.treeToValue(response.getData(), AiEvaluationResultResponse.class);
+                    saveEvaluationResult(aiEvalJob.getJobApplication(), result);
+                }
+                case RESUME -> {
+                    AiResumeAnalysisResponse result = objectMapper.treeToValue(response.getData(), AiResumeAnalysisResponse.class);
+                    saveResumeResult(aiEvalJob.getJobApplication(), result);
+                }
+                case PORTFOLIO -> {
+                    AiPortfolioAnalysisResponse result = objectMapper.treeToValue(response.getData(), AiPortfolioAnalysisResponse.class);
+                    savePortfolioResult(aiEvalJob.getJobApplication(), result);
+                }
+                default -> throw new IllegalArgumentException("지원하지 않는 분석 타입: " + aiEvalJob.getAnalysisType());
+            }
+            aiEvalJob.complete();
+            aiEvalJobRepository.save(aiEvalJob);
+            log.info("AI 분석 완료 처리 - evalJobId: {}, type: {}", evalJobId, aiEvalJob.getAnalysisType());
+        } catch (Exception e) {
+            log.error("AI 결과 저장 실패 - evalJobId: {}", evalJobId, e);
+            aiEvalJob.fail(e.getMessage());
+            aiEvalJobRepository.save(aiEvalJob);
+        }
+    }
+
+    private void saveEvaluationResult(JobApplication application, AiEvaluationResultResponse result) {
+
+        List<EvaluationCriteria> criteria = result.getEvaluationCriteria() != null
+                ? result.getEvaluationCriteria().stream()
+                .map(c -> new EvaluationCriteria(c.getName(), c.getDescription()))
+                .collect(Collectors.toList())
+                : null;
+
+        List<EvaluationScore> evaluationScores = result.getCompetencyScores().stream()
+                .map(cs -> new EvaluationScore(cs.getName(), cs.getScore(), cs.getDescription()))
+                .collect(Collectors.toList());
+
+        if (criteria != null) {
+            JobMaster jobMaster = application.getJobMaster();
+            jobMaster.updateEvaluationCriteria(criteria);
+            jobMasterRepository.save(jobMaster);
+        }
+
+        Optional<AiApplicantEvaluation> existingOpt = aiApplicationEvaluationRepository
+                .findByJobApplicationId(application.getId());
+        if (existingOpt.isPresent()) {
+            AiApplicantEvaluation existing = existingOpt.get();
+            existing.updateEvaluation(
+                    result.getOverallScore(),
+                    result.getOneLineReview(),
+                    result.getFeedbackDetail(),
+                    evaluationScores);
+            aiApplicationEvaluationRepository.save(existing);
+            log.info("AI 평가 결과 업데이트 완료: ApplicationId={}", application.getId());
+        } else {
+            AiApplicantEvaluation evaluation = AiApplicantEvaluation.builder()
+                    .jobApplication(application)
+                    .overallScore(result.getOverallScore())
+                    .oneLineReview(result.getOneLineReview())
+                    .feedbackDetail(result.getFeedbackDetail())
+                    .comparisonScores(evaluationScores)
+                    .build();
+
+            aiApplicationEvaluationRepository.save(evaluation);
+            log.info("AI 평가 결과 신규 저장 완료: {}", application.getId());
+        }
+    }
+
+    private void saveResumeResult(JobApplication application, AiResumeAnalysisResponse result) {
+        aiResumeAnalysisRepository.findByJobApplicationId(application.getId())
+                .ifPresentOrElse(
+                        existing -> {
+                            existing.update(result.getAiAnalysisReport(), result.getJobFitScore(),
+                                    result.getExperienceClarityScore(), result.getReadabilityScore());
+                            aiResumeAnalysisRepository.save(existing);
+                            log.info("이력서 분석 결과 업데이트 완료: ApplicationId={}", application.getId());
+                        }, () -> {
+                            aiResumeAnalysisRepository.save(AiResumeAnalysis.builder()
+                                    .jobApplication(application)
+                                    .aiAnalysisReport(result.getAiAnalysisReport())
+                                    .jobFitScore(result.getJobFitScore())
+                                    .experienceClarityScore(result.getExperienceClarityScore())
+                                    .readabilityScore(result.getReadabilityScore())
+                                    .build());
+                            log.info("이력서 분석 결과 신규 저장 완료: ApplicationId={}", application.getId());
+                        });
+    }
+
+    private void savePortfolioResult(JobApplication application, AiPortfolioAnalysisResponse result) {
+        aiPortfolioAnalysisRepository.findByJobApplicationId(application.getId())
+                .ifPresentOrElse(
+                        existing -> {
+                            existing.update(result.getAiAnalysisReport(), result.getProblemSolvingScore(),
+                                    result.getContributionClarityScore(), result.getTechnicalDepthScore());
+                            aiPortfolioAnalysisRepository.save(existing);
+                            log.info("포트폴리오 분석 결과 업데이트 완료: ApplicationId={}", application.getId());
+                        },
+                        () -> {
+                            aiPortfolioAnalysisRepository.save(AiPortfolioAnalysis.builder()
+                                    .jobApplication(application)
+                                    .aiAnalysisReport(result.getAiAnalysisReport())
+                                    .problemSolvingScore(result.getProblemSolvingScore())
+                                    .contributionClarityScore(result.getContributionClarityScore())
+                                    .technicalDepthScore(result.getTechnicalDepthScore())
+                                    .build());
+                            log.info("포트폴리오 분석 결과 신규 저장 완료: ApplicationId={}", application.getId());
+                        });
+    }
+}

--- a/src/main/java/com/thunder11/scuad/jobposting/service/JobApplicationService.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/JobApplicationService.java
@@ -69,7 +69,12 @@ public class JobApplicationService {
             saveDocument(application, "PORTFOLIO", portfolio);
         }
 
-        analysisService.createEvaluationJob(application.getId(), userId, "ALL");
+        analysisService.createEvaluationJob(application.getId(), userId, "EVALUATION");
+        analysisService.createEvaluationJob(application.getId(), userId, "RESUME");
+
+        if (portfolio != null && !portfolio.isEmpty()) {}
+        analysisService.createEvaluationJob(application.getId(), userId, "PORTFOLIO");
+
 
         return application.getId();
     }

--- a/src/main/java/com/thunder11/scuad/jobposting/service/JopApplicationAnalysisService.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/JopApplicationAnalysisService.java
@@ -159,19 +159,6 @@ public class JopApplicationAnalysisService {
             throw new ApiException(ErrorCode.NOT_FOUND, "이력서가 없습니다.");
         }
 
-        if (analysisType == AnalysisType.ALL) {
-            boolean hasPortfolio = jobApplication.getApplicationDocuments().stream()
-                    .anyMatch(d -> d.getDocType() == ApplicationDocumentType.PORTFOLIO);
-
-            createJobOnlyWithPending(jobApplication, userId, AnalysisType.EVALUATION);
-            createJobOnlyWithPending(jobApplication, userId, AnalysisType.RESUME);
-            if(hasPortfolio) {
-                createJobOnlyWithPending(jobApplication, userId, AnalysisType.PORTFOLIO);
-            }
-            eventPublisher.publishEvent(new AiAnalysisCreateEvent(userId, jobApplication.getJobMaster().getId(), AnalysisType.ALL));
-            return null;
-        }
-
         aiEvalJobRepository.findFirstByJobApplicationIdAndAnalysisTypeOrderByIdDesc(applicationId, analysisType)
                 .ifPresent(aiEvalJob -> {
                     if (aiEvalJob.getStatus() == AiJobStatus.PROCESSING) {
@@ -194,20 +181,6 @@ public class JopApplicationAnalysisService {
                 savedAiEvalJob.getId(), jobApplication.getId(), savedAiEvalJob.getStatus());
 
         eventPublisher.publishEvent(new AiAnalysisCreateEvent(userId, jobApplication.getJobMaster().getId(), analysisType));
-
-        return savedAiEvalJob.getId();
-    }
-
-    private Long createJobOnlyWithPending(JobApplication jobApplication, Long userId, AnalysisType analysisType) {
-        AiEvalJob aiEvalJob = AiEvalJob.builder()
-                .jobApplication(jobApplication)
-                .requestedBy(jobApplication.getUser())
-                .analysisType(analysisType)
-                .status(AiJobStatus.PENDING)
-                .build();
-
-        AiEvalJob savedAiEvalJob = aiEvalJobRepository.save(aiEvalJob);
-        log.info("AI 평가 접수 완료(PENDING/이벤트 미발행): ID={}, Type={}", savedAiEvalJob.getId(), analysisType);
 
         return savedAiEvalJob.getId();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,13 @@ spring:
       max-file-size: 20MB
       max-request-size: 20MB
 
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USERNAME:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+
+
 kakao:
   client-id: ${KAKAO_CLIENT_ID:default-client-id}
   client-secret: ${KAKAO_CLIENT_SECRET:default-client-secret}


### PR DESCRIPTION
@marha-hwang 
기존 `@Async` 기반 AI 분석 직접 HTTP 호출 방식을 RabbitMQ 메시지 큐를 통한 비동기 처리 방식으로 전환합니다. 채용공고분석은 이후 비동기로 전환할 예정입니다. 

### callback URL
`POST https://{백엔드_서버_도메인}/api/internal/ai/callback`

### RabbitMQ 확인 
<img width="3024" height="1916" alt="image" src="https://github.com/user-attachments/assets/56e642cd-8aa1-43dc-b0e8-a3286b6f5e0d" />

curl을 통해 동작 확인 결과, DB에 저장되는 것을 확인했습니다.

### 종합평가
<img width="1788" height="528" alt="image" src="https://github.com/user-attachments/assets/3ccfee0b-2eab-4888-bac8-b98a99e3277c" />
<img width="2000" height="297" alt="image" src="https://github.com/user-attachments/assets/dfeb575b-0245-445b-9c29-0be449ad5026" />


### 이력서
<img width="1788" height="518" alt="image" src="https://github.com/user-attachments/assets/37937f93-4dfa-489b-ad60-e41df1fab396" />
<img width="2000" height="297" alt="image" src="https://github.com/user-attachments/assets/cfc8addd-6260-48bf-9869-05e876840c94" />

### 포트폴리오
<img width="1554" height="670" alt="image" src="https://github.com/user-attachments/assets/39302d29-422c-4806-84d3-ee79fbfa8ac7" />
<img width="2000" height="297" alt="image" src="https://github.com/user-attachments/assets/56e3da70-04c1-4aff-8b86-0eb5ccb7bc89" />




