### PR TITLE
fix: 채팅방 동시 입장 시 정원 초과되는 race condition 수정

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomRepository.java
@@ -3,8 +3,10 @@ package com.thunder11.scuad.chat.repository;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,6 +18,14 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         // 채팅방 ID로 조회 (삭제되지 않은 것만)
         @Query("SELECT cr FROM ChatRoom cr WHERE cr.chatRoomId = :chatRoomId AND cr.deletedAt IS NULL")
         Optional<ChatRoom> findByIdNotDeleted(@Param("chatRoomId") Long chatRoomId);
+
+        // 채팅방 ID로 조회 + 비관적 락 (SELECT FOR UPDATE)
+        // 이유: 동시 입장 요청 시 정원 체크(count)와 저장(save) 사이의 gap에서 race condition 발생
+        //       첫 번째 요청이 이 락을 잡는 순간 두 번째 요청은 락 해제까지 대기하므로
+        //       정원 체크가 항상 최신 값을 기준으로 직렬화됨
+        @Lock(LockModeType.PESSIMISTIC_WRITE)
+        @Query("SELECT cr FROM ChatRoom cr WHERE cr.chatRoomId = :chatRoomId AND cr.deletedAt IS NULL")
+        Optional<ChatRoom> findByIdWithLock(@Param("chatRoomId") Long chatRoomId);
 
         // 공고별 채팅방 개수 조회 (ACTIVE 상태만)
         long countByJobMasterIdAndStatusAndDeletedAtIsNull(Long jobMasterId, RoomStatus status);

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -392,8 +392,13 @@ public class ChatRoomService {
     public void joinChatRoom(Long chatRoomId, Long userId) {
         log.info("채팅방 입장 시작: chatRoomId={}, userId={}", chatRoomId, userId);
 
-        // 1. 채팅방 존재 확인
-        ChatRoom chatRoom = chatRoomRepository.findByIdNotDeleted(chatRoomId)
+        // 1. 채팅방 조회 + 비관적 락 획득 (SELECT FOR UPDATE)
+        // 변경 이유: 기존 findByIdNotDeleted()는 락 없이 조회하므로
+        //           count() → save() 사이 gap에서 두 트랜잭션이 동시에 정원 체크를 통과하는
+        //           race condition이 발생했음 (k6 테스트로 재현 확인)
+        //           findByIdWithLock()으로 변경하면 첫 번째 트랜잭션이 commit할 때까지
+        //           두 번째 트랜잭션이 대기하므로 정원 체크가 항상 최신 값 기준으로 직렬화됨
+        ChatRoom chatRoom = chatRoomRepository.findByIdWithLock(chatRoomId)
                 .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
         // 2. 채팅방 상태 확인 (ACTIVE만 입장 가능)


### PR DESCRIPTION
<html><head></head><body><h1>FIX: 채팅방 동시 입장 시 정원 초과 허용되는 Race Condition 수정</h1>
<hr>
<h2>작업 내용</h2>
<h3><strong>커밋 1: 채팅방 동시 입장 시 정원 초과되는 race condition 수정</strong></h3>
<ul>
<li><code>ChatRoomRepository</code>에 <code>findByIdWithLock()</code> 메서드 추가
<ul>
<li><code>@Lock(LockModeType.PESSIMISTIC_WRITE)</code> 적용 → <code>SELECT FOR UPDATE</code> 실행</li>
<li>기존 <code>findByIdNotDeleted()</code>와 동일한 쿼리, 락만 추가</li>
<li><code>jakarta.persistence.LockModeType</code>, <code>org.springframework.data.jpa.repository.Lock</code> import 추가</li>
</ul>
</li>
<li><code>ChatRoomService.joinChatRoom()</code>에서 채팅방 조회를 <code>findByIdNotDeleted()</code> → <code>findByIdWithLock()</code>으로 변경
<ul>
<li>변경 위치: <code>joinChatRoom()</code> 내 1번 단계 (채팅방 존재 확인)</li>
<li>변경 이유 주석 추가</li>
</ul>
</li>
</ul>
<hr>
<h2>문제 상황</h2>
<h3><strong>증상</strong></h3>
<p>정원 2명인 채팅방(방장 1명 선점, 남은 자리 1개)에 2명이 <strong>동시에</strong> 입장 요청을 보냈을 때,
두 요청 <strong>모두 200 OK</strong>를 반환하며 정원을 초과한 3명이 저장됨.</p>
<pre><code>k6 동시 요청 결과:
  userId=4 → 200 OK  (CHAT_ROOM_JOINED)
  userId=5 → 200 OK  (CHAT_ROOM_JOINED)

테스트 후 DB:
  chat_room_members WHERE chat_room_id = 2 → 3건 (정원 2명 초과)
</code></pre>
<p>서버 로그에서 두 요청의 타임스탬프가 ms 단위까지 동일함을 확인.</p>
<pre><code>11:03:37.615 [nio-8080-exec-4] 채팅방 입장 완료: chatRoomId=2, userId=5
11:03:37.615 [nio-8080-exec-3] 채팅방 입장 완료: chatRoomId=2, userId=4
</code></pre>
<hr>
<h2>원인 분석</h2>
<h3><strong>왜 정원 초과가 발생했나?</strong></h3>
<p><code>joinChatRoom()</code>의 정원 확인 로직이 <strong>조회(count)와 저장(save)을 원자적으로 처리하지 않기 때문</strong>이다.</p>
<pre><code>[트랜잭션 A (userId=4)]           [트랜잭션 B (userId=5)]
  ↓
countByChatRoomId() → 1명         countByChatRoomId() → 1명   ← 둘 다 1명으로 읽음
  ↓                                 ↓
1 &lt; 2(정원) → 통과                 1 &lt; 2(정원) → 통과          ← 둘 다 통과
  ↓                                 ↓
save(MEMBER)                       save(MEMBER)                ← 둘 다 저장 → 정원 초과
</code></pre>
<p><code>count()</code> 조회는 현재 커밋된 값을 읽으므로, 두 트랜잭션이 동시에 "자리가 있다"는 결과를 받고 모두 저장까지 진행된다.</p>
<h3><strong>왜 놓쳤나?</strong></h3>
<p>단일 요청 시나리오에서는 정원 체크가 정상 동작한다.
동시 요청 테스트 없이 기능 검증만 진행했기 때문에 구현 단계에서 드러나지 않았다.</p>
<hr>
<h2>해결 방법</h2>
<p>채팅방 조회 시점에 <code>SELECT FOR UPDATE</code>로 DB 행 수준 락을 획득한다.
첫 번째 트랜잭션이 락을 잡으면 두 번째 트랜잭션은 락이 해제될 때까지 대기하므로,
정원 체크가 항상 최신 상태를 기준으로 직렬화된다.</p>
<pre><code class="language-java">// ChatRoomRepository.java - 추가
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("SELECT cr FROM ChatRoom cr WHERE cr.chatRoomId = :chatRoomId AND cr.deletedAt IS NULL")
Optional&lt;ChatRoom&gt; findByIdWithLock(@Param("chatRoomId") Long chatRoomId);
</code></pre>
<pre><code class="language-java">// ChatRoomService.java - joinChatRoom() 변경 전
ChatRoom chatRoom = chatRoomRepository.findByIdNotDeleted(chatRoomId)  // 락 없음
    .orElseThrow(...);

// 변경 후
ChatRoom chatRoom = chatRoomRepository.findByIdWithLock(chatRoomId)    // SELECT FOR UPDATE
    .orElseThrow(...);
</code></pre>
<p>직렬화 후 흐름:</p>
<pre><code>[트랜잭션 A]  findByIdWithLock() → 락 획득
              count() → 1명 → 통과 → save() → commit → 락 해제
                                    [트랜잭션 B]  락 획득
                                                 count() → 2명 → 정원 초과 → 409 반환
</code></pre>
<h3><strong>다른 방법과 비교한 이유</strong></h3>

방법 | 탈락 이유
-- | --
JVM synchronized | 서버 다중 인스턴스 환경에서 JVM 간 락 공유 불가
낙관적 락 (@Version) | 정원 경쟁처럼 충돌이 빈번한 경우 재시도 폭주로 성능 저하
Redis 분산 락 | DB 락으로 해결 가능한 범위에서 인프라 추가는 오버엔지니어링
비관적 락 (SELECT FOR UPDATE) | 채팅방 단위 행 락으로 범위가 좁고, 재시도 없이 한 번에 직렬화 가능


<hr>
<h2>검증 방법</h2>
<ol>
<li><code>V5__concurrency_test_data.sql</code> 시드 데이터 적용 (chat_room_id=2, max_participants=2)</li>
<li><code>LocalTokenController</code>로 userId=4, userId=5 토큰 발급</li>
<li>k6 동시 테스트 실행
<pre><code class="language-bash">k6 run -e TOKEN_USER4=$TOKEN4 -e TOKEN_USER5=$TOKEN5 k6/issue6_concurrent_join.js
</code></pre></li>
<li>기대 결과
<ul>
<li>한 명만 200 OK, 다른 한 명은 409 (CHAT_ROOM_FULL)</li>
<li>DB: <code>chat_room_members WHERE chat_room_id = 2</code> → <strong>2건</strong> (정원 초과 없음)</li>
</ul>
</li>
</ol></body></html>