### PR TITLE
fix: 동시 카카오 로그인 시 닉네임 중복 저장되는 race condition 수정

### DIFF
--- a/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
+++ b/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.dao.DataIntegrityViolationException;
+
 import com.thunder11.scuad.auth.domain.*;
 import com.thunder11.scuad.auth.dto.TokenRefreshResponse;
 import com.thunder11.scuad.common.exception.ApiException;
@@ -103,42 +105,57 @@ public class AuthService {
     // 신규 사용자 회원가입 처리
     // 카카오 정보로 User와 UserOAuthAccount 생성
     private UserOAuthAccount registerNewUser(KakaoUserInfoResponse userInfo) {
-        // 1. User 엔티티 생성
-        String nickname = generateUniqueNickname(userInfo);
-        
-        User newUser = User.builder()
-                .nickname(nickname)
-                .role(Role.USER)  // 기본 역할
-                .status(UserStatus.ACTIVE)  // 활성 상태
-                .build();
-        
-        User savedUser = userRepository.save(newUser);
-        log.info("신규 사용자 생성: userId={}, nickname={}", savedUser.getUserId(), nickname);
+        // 닉네임 중복 race condition 방지를 위해 existsByNickname() 체크를 제거하고
+        // DB UNIQUE 제약을 방어막으로 사용.
+        // 충돌 시 DataIntegrityViolationException을 잡아 suffix를 붙여 재시도.
+        // 최대 10회로 상한을 두어 무한 루프 방지.
+        String baseNickname = extractBaseNickname(userInfo);
+        int maxRetry = 10;
 
-        // 2. UserOAuthAccount 엔티티 생성
-        String email = extractEmail(userInfo);
-        
-        UserOAuthAccount oAuthAccount = UserOAuthAccount.builder()
-                .user(savedUser)
-                .email(email)
-                .provider(OAuthProvider.KAKAO)
-                .providerUserId(String.valueOf(userInfo.getId()))
-                .providerEmail(email)
-                .connectedAt(LocalDateTime.now())
-                .build();
+        for (int attempt = 0; attempt < maxRetry; attempt++) {
+            String candidateNickname = attempt == 0 ? baseNickname : baseNickname + attempt;
 
-        UserOAuthAccount savedOAuthAccount = oAuthAccountRepository.save(oAuthAccount);
-        log.info("OAuth 계정 연동 완료: provider=KAKAO, kakaoUserId={}", userInfo.getId());
+            try {
+                // 1. User 엔티티 생성 및 즉시 flush (DB UNIQUE 제약 위반 즉시 감지)
+                User newUser = User.builder()
+                        .nickname(candidateNickname)
+                        .role(Role.USER)
+                        .status(UserStatus.ACTIVE)
+                        .build();
 
-        return savedOAuthAccount;
+                User savedUser = userRepository.saveAndFlush(newUser);
+                log.info("신규 사용자 생성: userId={}, nickname={}", savedUser.getUserId(), candidateNickname);
+
+                // 2. UserOAuthAccount 엔티티 생성
+                String email = extractEmail(userInfo);
+
+                UserOAuthAccount oAuthAccount = UserOAuthAccount.builder()
+                        .user(savedUser)
+                        .email(email)
+                        .provider(OAuthProvider.KAKAO)
+                        .providerUserId(String.valueOf(userInfo.getId()))
+                        .providerEmail(email)
+                        .connectedAt(LocalDateTime.now())
+                        .build();
+
+                UserOAuthAccount savedOAuthAccount = oAuthAccountRepository.save(oAuthAccount);
+                log.info("OAuth 계정 연동 완료: provider=KAKAO, kakaoUserId={}", userInfo.getId());
+
+                return savedOAuthAccount;
+
+            } catch (DataIntegrityViolationException e) {
+                // 닉네임 unique 제약 위반 → suffix 붙여 재시도
+                log.warn("닉네임 충돌, 재시도: nickname={}, attempt={}", candidateNickname, attempt + 1);
+            }
+        }
+
+        // 최대 재시도 초과 (정상적인 상황에서는 발생하지 않음)
+        log.error("닉네임 생성 실패: baseNickname={}, maxRetry={}", baseNickname, maxRetry);
+        throw new ApiException(ErrorCode.INTERNAL_ERROR);
     }
 
-    // 고유한 닉네임 생성
-// 카카오 닉네임이 중복이면 뒤에 숫자 추가
-    private String generateUniqueNickname(KakaoUserInfoResponse userInfo) {
-        String baseNickname = "사용자";  // 기본값을 먼저 설정
-
-        // Null-safe 체크: 각 단계마다 null 확인
+    // 카카오 닉네임 추출 (Null-safe)
+    private String extractBaseNickname(KakaoUserInfoResponse userInfo) {
         try {
             if (userInfo != null &&
                     userInfo.getKakaoAccount() != null &&
@@ -146,25 +163,14 @@ public class AuthService {
 
                 String kakaoNickname = userInfo.getKakaoAccount().getProfile().getNickname();
 
-                // 카카오 닉네임이 있고 비어있지 않으면 사용
                 if (kakaoNickname != null && !kakaoNickname.trim().isEmpty()) {
-                    baseNickname = kakaoNickname;
+                    return kakaoNickname;
                 }
             }
         } catch (Exception e) {
             log.warn("카카오 닉네임 추출 실패, 기본값 사용: {}", e.getMessage());
         }
-
-        // 중복 체크 및 고유 닉네임 생성
-        String nickname = baseNickname;
-        int suffix = 1;
-        while (userRepository.existsByNickname(nickname)) {
-            nickname = baseNickname + suffix;
-            suffix++;
-        }
-
-        log.info("생성된 닉네임: {}", nickname);
-        return nickname;
+        return "사용자";
     }
 
     // 이메일 추출 (없을 수 있음)


### PR DESCRIPTION
<html><head></head><body><h1>FIX: 동시 카카오 로그인 시 닉네임 중복 저장되는 Race Condition 수정</h1>
<hr>
<h2>작업 내용</h2>
<h3><strong>커밋 1: 동시 카카오 로그인 시 닉네임 중복 저장되는 race condition 수정</strong></h3>
<ul>
<li><code>generateUniqueNickname()</code> 메서드 제거
<ul>
<li><code>existsByNickname()</code> while 루프가 race condition의 원인이므로 완전 제거</li>
</ul>
</li>
<li><code>registerNewUser()</code> 재작성
<ul>
<li><code>saveAndFlush()</code>로 즉시 DB 반영 → unique 제약 위반을 트랜잭션 내에서 즉시 감지</li>
<li><code>DataIntegrityViolationException</code> catch → suffix를 붙여 재시도</li>
<li>최대 10회 재시도 상한 적용, 초과 시 <code>INTERNAL_ERROR</code> 반환</li>
</ul>
</li>
<li><code>extractBaseNickname()</code> 추가
<ul>
<li>닉네임 추출 로직을 별도 메서드로 분리 (Null-safe)</li>
</ul>
</li>
<li><code>DataIntegrityViolationException</code> import 추가</li>
</ul>
<hr>
<h2>문제 상황</h2>
<h3><strong>증상</strong></h3>
<p>동일한 카카오 닉네임을 가진 신규 유저 여러 명이 <strong>동시에</strong> 첫 로그인을 시도했을 때,
일부 유저에게 <strong>500 응답</strong>이 반환됨.</p>
<pre><code>JUnit 동시성 테스트 결과 (스레드 5개, 동일 닉네임):
  성공          : 1
  실패(예외)    : 4
  저장된 유저 수: 1
  발생 예외     : DataIntegrityViolationException
</code></pre>
<p>에러 로그:</p>
<pre><code>ERROR o.h.engine.jdbc.spi.SqlExceptionHelper : Unique index or primary key violation:
"PUBLIC.CONSTRAINT_INDEX_4D ON PUBLIC.USERS(NICKNAME NULLS FIRST) VALUES ('레이스닉네임')"
SQL: insert into users (..., nickname, ...) values (...)
</code></pre>
<hr>
<h2>원인 분석</h2>
<h3><strong>왜 중복 저장이 발생했나?</strong></h3>
<p><code>generateUniqueNickname()</code>의 중복 체크 로직이 <strong>조회(existsByNickname)와 저장(save)을 원자적으로 처리하지 않기 때문</strong>이다.</p>
<pre><code>[스레드 A]  existsByNickname("레이스닉네임") → false
[스레드 B]  existsByNickname("레이스닉네임") → false   ← 동시에 모두 false 반환
[스레드 C]  existsByNickname("레이스닉네임") → false
     ↓
[스레드 A]  save("레이스닉네임") → 성공
[스레드 B]  save("레이스닉네임") → ❌ unique constraint 위반 → 500
[스레드 C]  save("레이스닉네임") → ❌ unique constraint 위반 → 500
</code></pre>
<h3><strong>왜 비관적 락을 쓰지 않았나?</strong></h3>
<p>비관적 락(<code>SELECT FOR UPDATE</code>)은 이미 존재하는 DB 행에만 걸 수 있다.
닉네임은 아직 존재하지 않는 행이므로 락을 걸 대상이 없어 구조적으로 적용 불가다.</p>
<h3><strong>왜 놓쳤나?</strong></h3>
<p>단일 요청 시나리오에서는 중복 체크가 정상 동작한다.
동시 요청 테스트 없이 기능 검증만 진행했기 때문에 구현 단계에서 드러나지 않았다.</p>
<hr>
<h2>해결 방법</h2>
<p><code>existsByNickname()</code> 체크를 제거하고 DB UNIQUE 제약을 유일한 보호 수단으로 삼는다.
<code>saveAndFlush()</code>로 즉시 flush하여 충돌을 트랜잭션 내에서 감지하고,
<code>DataIntegrityViolationException</code> 발생 시 suffix를 붙여 재시도한다.</p>
<pre><code class="language-java">// 변경 전: existsByNickname() 체크 → race condition 발생
String nickname = baseNickname;
int suffix = 1;
while (userRepository.existsByNickname(nickname)) {  // ← race condition 원인
    nickname = baseNickname + suffix;
    suffix++;
}
User savedUser = userRepository.save(newUser);
</code></pre>
<pre><code class="language-java">// 변경 후: DB UNIQUE 제약 + saveAndFlush() + 재시도 상한
for (int attempt = 0; attempt &lt; 10; attempt++) {
    String candidateNickname = attempt == 0 ? baseNickname : baseNickname + attempt;
    try {
        User savedUser = userRepository.saveAndFlush(newUser);  // 즉시 flush → 충돌 즉시 감지
        // OAuth 계정, RefreshToken 저장...
        return savedOAuthAccount;
    } catch (DataIntegrityViolationException e) {
        log.warn("닉네임 충돌, 재시도: nickname={}, attempt={}", candidateNickname, attempt + 1);
    }
}
throw new ApiException(ErrorCode.INTERNAL_ERROR);
</code></pre>
<h3><strong>다른 방법과 비교한 이유</strong></h3>

방법 | 탈락 이유
-- | --
JVM synchronized | 서버 다중 인스턴스 환경에서 JVM 간 락 공유 불가
비관적 락 (SELECT FOR UPDATE) | 존재하지 않는 행에는 락을 걸 수 없어 구조적으로 적용 불가
Redis 분산 락 | DB 제약으로 해결 가능한 범위에서 인프라 추가는 오버엔지니어링
DB UNIQUE 제약 + saveAndFlush + 재시도 상한 | 추가 인프라 없이 해결, 재시도 상한으로 무한 루프 방지


<hr>
<h2>검증 방법</h2>
<ol>
<li><code>NicknameConcurrencyTest</code> 실행 (스레드 5개, 동일 닉네임 동시 요청)
<pre><code>경로: src/test/java/com/thunder11/scuad/scuad/NicknameConcurrencyTest.java
</code></pre></li>
<li>기대 결과
<ul>
<li>성공 5, 실패 0</li>
<li>저장된 유저 수: 5</li>
<li>닉네임: <code>레이스닉네임</code>, <code>레이스닉네임1</code>, <code>레이스닉네임2</code>, <code>레이스닉네임3</code>, <code>레이스닉네임4</code></li>
</ul>
</li>
</ol></body></html>