### PR TITLE
fix: 닉네임 중복 재시도 시 JPA 세션 오염으로 AssertionFailure 발생하는 문제 수정

### DIFF
--- a/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
+++ b/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
@@ -44,6 +44,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final UserOAuthAccountRepository oAuthAccountRepository;
     private final AuthRefreshTokenRepository refreshTokenRepository;
+    private final UserRegistrationHelper userRegistrationHelper;
 
     // 카카오 OAuth 인증 URL 생성
     // 프론트엔드를 카카오 로그인 페이지로 리다이렉트하기 위한 URL 생성
@@ -103,53 +104,29 @@ public class AuthService {
     }
 
     // 신규 사용자 회원가입 처리
-    // 카카오 정보로 User와 UserOAuthAccount 생성
+    // 세션 오염 방지를 위해 유저 저장을 UserRegistrationHelper(REQUIRES_NEW)에 위임.
+    // 충돌 시 해당 트랜잭션만 롤백되므로 재시도 시 깨끗한 세션으로 진입 가능.
     private UserOAuthAccount registerNewUser(KakaoUserInfoResponse userInfo) {
-        // 닉네임 중복 race condition 방지를 위해 existsByNickname() 체크를 제거하고
-        // DB UNIQUE 제약을 방어막으로 사용.
-        // 충돌 시 DataIntegrityViolationException을 잡아 suffix를 붙여 재시도.
-        // 최대 10회로 상한을 두어 무한 루프 방지.
         String baseNickname = extractBaseNickname(userInfo);
+        String email = extractEmail(userInfo);
+        String providerUserId = String.valueOf(userInfo.getId());
         int maxRetry = 10;
 
         for (int attempt = 0; attempt < maxRetry; attempt++) {
             String candidateNickname = attempt == 0 ? baseNickname : baseNickname + attempt;
 
             try {
-                // 1. User 엔티티 생성 및 즉시 flush (DB UNIQUE 제약 위반 즉시 감지)
-                User newUser = User.builder()
-                        .nickname(candidateNickname)
-                        .role(Role.USER)
-                        .status(UserStatus.ACTIVE)
-                        .build();
-
-                User savedUser = userRepository.saveAndFlush(newUser);
-                log.info("신규 사용자 생성: userId={}, nickname={}", savedUser.getUserId(), candidateNickname);
-
-                // 2. UserOAuthAccount 엔티티 생성
-                String email = extractEmail(userInfo);
-
-                UserOAuthAccount oAuthAccount = UserOAuthAccount.builder()
-                        .user(savedUser)
-                        .email(email)
-                        .provider(OAuthProvider.KAKAO)
-                        .providerUserId(String.valueOf(userInfo.getId()))
-                        .providerEmail(email)
-                        .connectedAt(LocalDateTime.now())
-                        .build();
-
-                UserOAuthAccount savedOAuthAccount = oAuthAccountRepository.save(oAuthAccount);
-                log.info("OAuth 계정 연동 완료: provider=KAKAO, kakaoUserId={}", userInfo.getId());
-
-                return savedOAuthAccount;
-
+                return userRegistrationHelper.tryCreateUser(
+                        candidateNickname,
+                        email,
+                        providerUserId,
+                        OAuthProvider.KAKAO
+                );
             } catch (DataIntegrityViolationException e) {
-                // 닉네임 unique 제약 위반 → suffix 붙여 재시도
                 log.warn("닉네임 충돌, 재시도: nickname={}, attempt={}", candidateNickname, attempt + 1);
             }
         }
 
-        // 최대 재시도 초과 (정상적인 상황에서는 발생하지 않음)
         log.error("닉네임 생성 실패: baseNickname={}, maxRetry={}", baseNickname, maxRetry);
         throw new ApiException(ErrorCode.INTERNAL_ERROR);
     }

--- a/src/main/java/com/thunder11/scuad/auth/service/UserRegistrationHelper.java
+++ b/src/main/java/com/thunder11/scuad/auth/service/UserRegistrationHelper.java
@@ -1,0 +1,62 @@
+package com.thunder11.scuad.auth.service;
+
+import com.thunder11.scuad.auth.domain.*;
+import com.thunder11.scuad.auth.repository.UserOAuthAccountRepository;
+import com.thunder11.scuad.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+// 신규 유저 저장 전용 헬퍼 빈
+//
+// 분리 이유:
+//   AuthService.processKakaoCallback()은 @Transactional이므로,
+//   내부에서 saveAndFlush()가 DataIntegrityViolationException을 던지면
+//   JPA 세션이 오염(rollback-only)되어 재시도 시 AssertionFailure 발생.
+//
+//   이 헬퍼를 REQUIRES_NEW로 선언하면 호출마다 독립 트랜잭션이 생성되고,
+//   예외 발생 시 해당 트랜잭션만 롤백 → 외부 세션은 오염되지 않음.
+//   → 재시도마다 깨끗한 세션으로 시도 가능
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserRegistrationHelper {
+
+    private final UserRepository userRepository;
+    private final UserOAuthAccountRepository oAuthAccountRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public UserOAuthAccount tryCreateUser(
+            String nickname,
+            String email,
+            String providerUserId,
+            OAuthProvider provider
+    ) {
+        User newUser = User.builder()
+                .nickname(nickname)
+                .role(Role.USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        User savedUser = userRepository.saveAndFlush(newUser);
+        log.info("신규 사용자 생성: userId={}, nickname={}", savedUser.getUserId(), nickname);
+
+        UserOAuthAccount oAuthAccount = UserOAuthAccount.builder()
+                .user(savedUser)
+                .email(email)
+                .provider(provider)
+                .providerUserId(providerUserId)
+                .providerEmail(email)
+                .connectedAt(LocalDateTime.now())
+                .build();
+
+        UserOAuthAccount savedOAuthAccount = oAuthAccountRepository.save(oAuthAccount);
+        log.info("OAuth 계정 연동 완료: provider={}, providerUserId={}", provider, providerUserId);
+
+        return savedOAuthAccount;
+    }
+}


### PR DESCRIPTION
# [fix] 닉네임 중복 재시도 시 JPA 세션 오염으로 AssertionFailure 발생하는 문제 수정

## 1. 문제 상황

이슈11에서 닉네임 중복 race condition 개선을 위해 도입한 `saveAndFlush()` + `DataIntegrityViolationException` 재시도 로직이 테스트에서 정상 동작하지 않았습니다.

동시 로그인 테스트(5개 스레드) 결과:
- 성공: 1건
- 실패: 4건 (`AssertionFailure`)
```
AssertionFailure: Entry for instance of 'User' has a null identifier
(this can happen if the session is flushed after an exception occurs)
```

---

## 2. 원인 분석

`processKakaoCallback()`은 `@Transactional`로 선언되어 있습니다.
이 트랜잭션 내부에서 `saveAndFlush()`가 `DataIntegrityViolationException`을 던지면,
**같은 트랜잭션의 JPA 세션이 오염(rollback-only 상태)**됩니다.

이후 재시도 시 오염된 세션을 그대로 재사용하므로 `AssertionFailure`가 발생합니다.
```
[processKakaoCallback - @Transactional]
  └─ registerNewUser()
       └─ saveAndFlush() → DataIntegrityViolationException 발생
            → 같은 트랜잭션 세션 오염 (rollback-only)
       └─ 재시도: saveAndFlush() → 오염된 세션 재사용 → AssertionFailure
```

핵심은 **예외가 발생한 트랜잭션 세션은 재사용할 수 없다**는 점입니다.
재시도가 동일 트랜잭션 안에서 일어나는 한 이 문제는 해결되지 않습니다.

---

## 3. 해결 방법

유저 저장 로직을 `@Transactional(propagation = REQUIRES_NEW)`로 선언된
별도 빈(`UserRegistrationHelper`)으로 분리했습니다.

`REQUIRES_NEW`는 호출마다 **독립 트랜잭션**을 생성합니다.
예외 발생 시 해당 트랜잭션만 롤백되고 외부 트랜잭션 세션은 오염되지 않습니다.
재시도 시마다 깨끗한 세션으로 진입할 수 있게 됩니다.
```
[processKakaoCallback - @Transactional]  ← 외부 트랜잭션, 세션 정상 유지
  └─ registerNewUser()
       └─ userRegistrationHelper.tryCreateUser() [REQUIRES_NEW]  ← 독립 트랜잭션 1
            → DataIntegrityViolationException → 이 트랜잭션만 롤백
       └─ 재시도: tryCreateUser() [REQUIRES_NEW]  ← 독립 트랜잭션 2 (깨끗한 세션)
            → 성공
```

---

## 4. 변경 범위

### 새 파일: `AuthService` 내 `registerNewUser()` 로직 위임 대상

**`src/main/java/com/thunder11/scuad/auth/service/UserRegistrationHelper.java`**
- `@Component`, `@Transactional(propagation = REQUIRES_NEW)`
- `tryCreateUser()`: User + UserOAuthAccount 생성 및 저장
- 닉네임 UNIQUE 제약 위반 시 `DataIntegrityViolationException`을 그대로 던져 호출자가 재시도하도록 위임

### 기존 파일 수정

**`src/main/java/com/thunder11/scuad/auth/service/AuthService.java`**
- `registerNewUser()` 내부의 직접 저장 로직 제거
- `userRegistrationHelper.tryCreateUser()` 호출로 교체
- `UserRegistrationHelper` 필드 주입 추가

---

## 5. 변경 전/후 코드 비교

**변경 전** — 외부 트랜잭션 안에서 직접 저장
```java
// registerNewUser() 내부
User savedUser = userRepository.saveAndFlush(newUser);  // 예외 시 외부 세션 오염
```

**변경 후** — 독립 트랜잭션으로 위임
```java
// registerNewUser() 내부
return userRegistrationHelper.tryCreateUser(  // REQUIRES_NEW → 독립 트랜잭션
        candidateNickname, email, providerUserId, OAuthProvider.KAKAO
);
```

---

## 6. 검증 방법

`test/race-condition` 브랜치에서 `NicknameConcurrencyTest` 실행
- 스레드 5개 동시 로그인
- 기대 결과: 성공 5건, 실패 0건, 저장된 유저 수 5건 (닉네임 suffix로 구분)
```
[이슈11] 닉네임 race condition 결과
  동시 요청 수  : 5
  성공          : 5
  실패(예외)    : 0
  저장된 유저 수: 5
```