### PR TITLE
fix : AI 비교 동시 요청 시 중복 저장되는 race condition 수정

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java
@@ -3,6 +3,7 @@ package com.thunder11.scuad.chat.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -116,9 +117,22 @@ public class ChatMemberComparisonService {
                 .weaknessesReport(aiResponse.getWeaknessesReport())
                 .build();
 
-        AiApplicantComparison saved = aiApplicantComparisonRepository.save(comparison);
-        log.info("AI 비교 결과 저장 완료: comparisonId={}", saved.getId());
-
-        return ComparisonResponse.from(saved);
+        // race condition 대비: UNIQUE 제약 위반 시 이미 저장된 결과를 조회해서 반환
+        // 이유: 동시 요청으로 AI가 2번 호출되더라도 나중에 저장 시도한 건은
+        //       DataIntegrityViolationException으로 차단되고, 먼저 저장된 결과를 반환
+        //       → 사용자는 두 요청 모두 정상 응답을 받음
+        try {
+            AiApplicantComparison saved = aiApplicantComparisonRepository.save(comparison);
+            log.info("AI 비교 결과 저장 완료: comparisonId={}", saved.getId());
+            return ComparisonResponse.from(saved);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("AI 비교 결과 중복 저장 감지, 기존 결과 반환: myApplicationId={}, competitorApplicationId={}",
+                    myApplication.getId(), competitorApplication.getId());
+            return aiApplicantComparisonRepository
+                    .findByMyApplication_IdAndCompetitorApplication_Id(
+                            myApplication.getId(), competitorApplication.getId())
+                    .map(ComparisonResponse::from)
+                    .orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_ERROR));
+        }
     }
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/domain/AiApplicantComparison.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/domain/AiApplicantComparison.java
@@ -22,6 +22,15 @@ import com.thunder11.scuad.common.entity.BaseTimeEntity;
                 // (my_application_id, competitor_application_id) 조합으로 중복 체크 조회 최적화
                 @Index(name = "idx_comparison_my_competitor",
                         columnList = "my_application_id, competitor_application_id")
+        },
+        uniqueConstraints = {
+                // DB 레벨에서 동일 비교 조합 중복 저장 방지
+                // race condition 시 나중에 INSERT된 건이 DataIntegrityViolationException 발생
+                // → ChatMemberComparisonService에서 catch 후 기존 결과 반환
+                @UniqueConstraint(
+                        name = "uq_comparison_my_competitor",
+                        columnNames = {"my_application_id", "competitor_application_id"}
+                )
         }
 )
 

--- a/src/main/resources/db/migration/V5__add_unique_constraint_ai_applicant_comparison.sql
+++ b/src/main/resources/db/migration/V5__add_unique_constraint_ai_applicant_comparison.sql
@@ -1,0 +1,20 @@
+-- [이슈8] AI 비교 결과 중복 저장 방지를 위한 UNIQUE 제약 추가
+--
+-- 배경:
+--   ChatMemberComparisonService.compare()에서
+--   findBy → AI 호출(수 초) → save() 구조에 race condition 존재.
+--   동시 요청 시 두 요청 모두 "결과 없음"으로 판단해 AI를 중복 호출하고
+--   동일한 (my_application_id, competitor_application_id) 조합을 2건 저장함.
+--
+-- 해결:
+--   DB 레벨에서 중복 저장을 차단하는 UNIQUE 제약 추가.
+--   나중에 INSERT된 건은 DataIntegrityViolationException 발생 →
+--   서비스 레이어에서 catch 후 기존 결과를 조회해 반환.
+--
+-- 참고:
+--   기존 idx_comparison_my_competitor 인덱스는 조회 최적화 전용이었음.
+--   UNIQUE 제약은 별도로 추가해야 중복 방지 효과가 생김.
+
+ALTER TABLE ai_applicant_comparison
+    ADD CONSTRAINT uq_comparison_my_competitor
+        UNIQUE (my_application_id, competitor_application_id);


### PR DESCRIPTION
# [fix] AI 비교 동시 요청 시 중복 저장되는 race condition 수정

## 1. 문제 상황

채팅방에서 동일한 비교 조합(A vs B)에 동시 요청이 들어오면
AI API가 중복 호출되고 동일한 비교 결과가 DB에 2건 저장되는 race condition이 존재합니다.

동시 요청 재현 테스트(2개 스레드) 결과:

- 성공: 2건
- 실패(예외): 0건
- DB 저장 건수: **2건 (중복 저장)**

```
[이슈8] AI 비교 race condition 재현 결과
  동시 요청 수  : 2
  성공          : 2
  실패(예외)    : 0
  DB 저장 건수  : 2   ← 중복 저장 확인
```

<img width="2242" height="814" alt="image" src="https://github.com/user-attachments/assets/2ae7d9d6-6181-4305-9dae-d34630f78c1f" />

<img width="3000" height="230" alt="image" src="https://github.com/user-attachments/assets/17231d49-863b-4243-b955-4d12585acf7f" />

---

## 2. 원인 분석

`ChatMemberComparisonService.compare()`의 코드 구조는 다음과 같습니다.

```java
return aiApplicantComparisonRepository
        .findByMyApplication_IdAndCompetitorApplication_Id(...)
        .map(ComparisonResponse::from)
        .orElseGet(() -> callAiAndSave(...));  // ← 동시 요청 시 둘 다 여기 진입
```

두 요청이 동시에 `findBy`를 실행하면 둘 다 "결과 없음"으로 판단합니다.
이후 각자 AI API를 호출하고 `save()`를 시도하므로 동일한 비교 결과가 2건 저장됩니다.

이슈6, 이슈11과의 차이점이 여기 있습니다.

```
이슈6:  [count()]─────────────────[save()]           race condition 창: 수 ms
이슈11: [existsBy()]──────────────[saveAndFlush()]   race condition 창: 수 ms
이슈8:  [findBy()]──[AI 호출 수 초]──[save()]        race condition 창: 수 초  ← 훨씬 넓음
```

AI API 호출(수 초)이 race condition 창 사이에 끼어 있어 **경쟁 확률이 훨씬 높습니다.**

---

## 3. 해결 방법

**UNIQUE 제약 + `DataIntegrityViolationException` 처리** 방식을 선택했습니다.

### 후보 비교

| 방법 | 이슈8 적합 여부 | 이유 |
|---|---|---|
| 비관적 락 | ❌ | 락 보유 시간 = AI 호출 시간(수 초) → DB 커넥션 낭비 |
| 낙관적 락 | ❌ | 재시도 시 AI를 또 호출하는 구조라 해결 안 됨 |
| **UNIQUE 제약 + 예외처리** | ✅ | 락 없이 DB 레벨에서 중복 차단, 사용자 정상 응답 보장 |
| Redis 분산 락 | 🔺 | 현재 규모에서 과도한 인프라 추가 |

### 채택 이유 3가지

1. **락 보유 시간 문제 없음**: AI 호출 중 락을 잡으면 수 초간 DB 커넥션을 점유합니다. UNIQUE 제약은 락 없이 INSERT 시점에만 DB가 판단하므로 이 문제가 없습니다.
2. **사용자 경험 보장**: `DataIntegrityViolationException`을 catch해서 먼저 저장된 결과를 반환하므로, 동시 요청한 두 사용자 모두 정상 응답(200)을 받습니다. 리트라이나 에러 안내가 필요 없습니다.
3. **변경 범위 최소화**: 엔티티 어노테이션 1개 + 서비스 try-catch 1개 + Flyway 마이그레이션 1개로 변경이 끝납니다.

### 트레이드오프

AI가 최대 2번 호출될 수 있습니다.
현재 규모(동일 조합 동시 요청이 드문 상황)에서는 허용 가능한 트레이드오프입니다.
트래픽이 증가해 AI 호출 비용이 문제가 될 경우 Redis 분산 락으로 업그레이드를 검토합니다.

---

## 4. 동시 요청 시나리오별 동작

### 케이스 1: 기존 결과 없을 때 동시 요청

```
A: findBy → 결과 없음 → AI 호출 시작
B: findBy → 결과 없음 → AI 호출 시작  (동시)

A: save() 성공 → 정상 응답 반환 ✅
B: save() 시도 → UNIQUE 제약 위반 → DataIntegrityViolationException
   → catch → A가 저장한 기존 결과 조회 후 반환 ✅

결과: A, B 모두 200 정상 응답 / DB 1건 저장 / AI 2회 호출
```

### 케이스 2: 기존 결과 있을 때 동시 요청

```
A: findBy → 결과 있음 → 바로 반환 ✅
B: findBy → 결과 있음 → 바로 반환 ✅

결과: A, B 모두 200 정상 응답 / DB 변화 없음 / AI 호출 없음
```

---

## 5. 변경 범위

### `AiApplicantComparison.java`

`@UniqueConstraint` 추가

```java
// 변경 전
@Table(
        name = "ai_applicant_comparison",
        indexes = {
                @Index(name = "idx_comparison_my_competitor",
                        columnList = "my_application_id, competitor_application_id")
        }
)

// 변경 후
@Table(
        name = "ai_applicant_comparison",
        indexes = {
                @Index(name = "idx_comparison_my_competitor",
                        columnList = "my_application_id, competitor_application_id")
        },
        uniqueConstraints = {
                @UniqueConstraint(
                        name = "uq_comparison_my_competitor",
                        columnNames = {"my_application_id", "competitor_application_id"}
                )
        }
)
```

### `ChatMemberComparisonService.java`

`callAiAndSave()` 저장 부분에 예외처리 추가

```java
// 변경 전
AiApplicantComparison saved = aiApplicantComparisonRepository.save(comparison);
log.info("AI 비교 결과 저장 완료: comparisonId={}", saved.getId());
return ComparisonResponse.from(saved);

// 변경 후
try {
    AiApplicantComparison saved = aiApplicantComparisonRepository.save(comparison);
    log.info("AI 비교 결과 저장 완료: comparisonId={}", saved.getId());
    return ComparisonResponse.from(saved);
} catch (DataIntegrityViolationException e) {
    log.warn("AI 비교 결과 중복 저장 감지, 기존 결과 반환: myApplicationId={}, competitorApplicationId={}",
            myApplication.getId(), competitorApplication.getId());
    return aiApplicantComparisonRepository
            .findByMyApplication_IdAndCompetitorApplication_Id(
                    myApplication.getId(), competitorApplication.getId())
            .map(ComparisonResponse::from)
            .orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_ERROR));
}
```

### `V5__add_unique_constraint_ai_applicant_comparison.sql` (신규)

운영 DB에 UNIQUE 제약 반영을 위한 Flyway 마이그레이션 추가

```sql
ALTER TABLE ai_applicant_comparison
    ADD CONSTRAINT uq_comparison_my_competitor
        UNIQUE (my_application_id, competitor_application_id);
```

---

## 6. 검증 방법

`src/test/java/com/thunder11/scuad/scuad/ComparisonConcurrencyTest.java` 실행

- 스레드 2개 동시 `compare()` 호출
- `@MockBean AiServiceClient` + `Thread.sleep(500)`으로 AI 지연 시뮬레이션
- 기대 결과: 성공 2건, 실패 0건, DB 저장 1건

```
[이슈8] AI 비교 race condition 결과
  동시 요청 수  : 2
  성공          : 2
  실패(예외)    : 0
  DB 저장 건수  : 1   ← 중복 저장 방지 확인
```
