### PR TITLE
fix : JPA 세션 오염 방지

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/service/AiComparisonSaveHelper.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/AiComparisonSaveHelper.java
@@ -1,0 +1,34 @@
+package com.thunder11.scuad.chat.service;
+
+import com.thunder11.scuad.jobposting.domain.AiApplicantComparison;
+import com.thunder11.scuad.jobposting.repository.AiApplicantComparisonRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// AI 비교 결과 저장 전용 헬퍼 빈
+//
+// 분리 이유:
+//   ChatMemberComparisonService.compare()는 @Transactional이므로,
+//   내부에서 save()가 DataIntegrityViolationException을 던지면
+//   JPA 세션이 오염(rollback-only)되어 catch 후 findBy 시 AssertionFailure 발생.
+//
+//   이 헬퍼를 REQUIRES_NEW로 선언하면 호출마다 독립 트랜잭션이 생성되고,
+//   예외 발생 시 해당 트랜잭션만 롤백 → 외부 세션은 오염되지 않음.
+//   → catch 블록에서 깨끗한 세션으로 findBy 조회 가능
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiComparisonSaveHelper {
+
+    private final AiApplicantComparisonRepository aiApplicantComparisonRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public AiApplicantComparison trySave(AiApplicantComparison comparison) {
+        AiApplicantComparison saved = aiApplicantComparisonRepository.save(comparison);
+        log.info("AI 비교 결과 저장 완료: comparisonId={}", saved.getId());
+        return saved;
+    }
+}

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java
@@ -37,6 +37,7 @@ public class ChatMemberComparisonService {
     private final JobApplicationRepository jobApplicationRepository;
     private final AiApplicantComparisonRepository aiApplicantComparisonRepository;
     private final AiServiceClient aiServiceClient;
+    private final AiComparisonSaveHelper aiComparisonSaveHelper;
 
     @Transactional
     public ComparisonResponse compare(Long chatRoomId, Long requestUserId, Long chatRoomMemberId) {
@@ -107,7 +108,6 @@ public class ChatMemberComparisonService {
                 .map(m -> new ComparisonMetric(m.getName(), m.getMyScore(), m.getCompetitorScore()))
                 .collect(Collectors.toList());
 
-        // DB 저장
         AiApplicantComparison comparison = AiApplicantComparison.builder()
                 .jobMaster(jobMaster)
                 .myApplication(myApplication)
@@ -118,12 +118,13 @@ public class ChatMemberComparisonService {
                 .build();
 
         // race condition 대비: UNIQUE 제약 위반 시 이미 저장된 결과를 조회해서 반환
-        // 이유: 동시 요청으로 AI가 2번 호출되더라도 나중에 저장 시도한 건은
-        //       DataIntegrityViolationException으로 차단되고, 먼저 저장된 결과를 반환
-        //       → 사용자는 두 요청 모두 정상 응답을 받음
+        // REQUIRES_NEW 독립 트랜잭션으로 분리한 이유:
+        //   같은 트랜잭션 안에서 예외 발생 시 JPA 세션이 오염(rollback-only)되어
+        //   catch 후 findBy 시도 시 AssertionFailure 발생 → 이슈11과 동일한 문제
+        //   REQUIRES_NEW로 분리하면 예외 발생 시 내부 트랜잭션만 롤백되고
+        //   외부 세션은 깨끗하게 유지되어 findBy가 정상 동작함
         try {
-            AiApplicantComparison saved = aiApplicantComparisonRepository.save(comparison);
-            log.info("AI 비교 결과 저장 완료: comparisonId={}", saved.getId());
+            AiApplicantComparison saved = aiComparisonSaveHelper.trySave(comparison);
             return ComparisonResponse.from(saved);
         } catch (DataIntegrityViolationException e) {
             log.warn("AI 비교 결과 중복 저장 감지, 기존 결과 반환: myApplicationId={}, competitorApplicationId={}",


### PR DESCRIPTION
# [fix] AI 비교 중복 저장 방지 시 JPA 세션 오염으로 AssertionFailure 발생하는 문제 수정

## 1. 문제 상황

UNIQUE 제약 + `DataIntegrityViolationException` 처리를 적용한 후
동시성 테스트(2개 스레드)에서 정상 동작하지 않았습니다.

- 성공: 1건
- 실패: 1건 (`AssertionFailure`)
- DB 저장 건수: 1건
```
AssertionFailure: Entry for instance of 'AiApplicantComparison' has a null identifier
(this can happen if the session is flushed after an exception occurs)
```

<img width="3032" height="1516" alt="image" src="https://github.com/user-attachments/assets/69789890-1397-4d9e-8c6d-ed325e93eb80" />


---

## 2. 원인 분석

`compare()`는 `@Transactional`로 선언되어 있습니다.
이 트랜잭션 내부에서 `save()`가 `DataIntegrityViolationException`을 던지면
**같은 트랜잭션의 JPA 세션이 오염(rollback-only 상태)**됩니다.
이후 catch 블록에서 `findBy`를 시도해도 오염된 세션을 재사용하므로 `AssertionFailure`가 발생합니다.
```
[compare() - @Transactional]
  └─ callAiAndSave()
       └─ save() → DataIntegrityViolationException 발생
            → 같은 트랜잭션 세션 오염 (rollback-only)
       └─ catch: findBy() → 오염된 세션 재사용 → AssertionFailure
```

---

## 3. 해결 방법

저장 로직을 `@Transactional(propagation = REQUIRES_NEW)`로 선언된
별도 빈(`AiComparisonSaveHelper`)으로 분리했습니다.

`REQUIRES_NEW`는 호출마다 **독립 트랜잭션**을 생성합니다.
예외 발생 시 해당 트랜잭션만 롤백되고 외부 트랜잭션 세션은 오염되지 않습니다.
catch 블록에서 `findBy` 시 깨끗한 세션으로 조회할 수 있게 됩니다.
```
[compare() - @Transactional]              ← 외부 트랜잭션, 세션 정상 유지
  └─ callAiAndSave()
       └─ aiComparisonSaveHelper.trySave() [REQUIRES_NEW]  ← 독립 트랜잭션
            → DataIntegrityViolationException → 이 트랜잭션만 롤백
       └─ catch → findBy (외부 세션은 깨끗) → 기존 결과 반환 ✅
```

---

## 4. 변경 범위

### 새 파일: `AiComparisonSaveHelper`

**`src/main/java/com/thunder11/scuad/chat/service/AiComparisonSaveHelper.java`**

- `@Component`, `@Transactional(propagation = REQUIRES_NEW)`
- `trySave()`: AI 비교 결과 저장 전담
- UNIQUE 제약 위반 시 `DataIntegrityViolationException`을 그대로 던져 호출자가 처리하도록 위임

### 기존 파일 수정

**`src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java`**

- `AiComparisonSaveHelper` 필드 주입 추가
- `callAiAndSave()` 내 직접 `save()` 호출 → `aiComparisonSaveHelper.trySave()` 호출로 교체

---

## 5. 변경 전/후 코드 비교

**변경 전** — 외부 트랜잭션 안에서 직접 저장
```java
// callAiAndSave() 내부
try {
    AiApplicantComparison saved = aiApplicantComparisonRepository.save(comparison); // 예외 시 외부 세션 오염
    return ComparisonResponse.from(saved);
} catch (DataIntegrityViolationException e) {
    // 오염된 세션으로 findBy 시도 → AssertionFailure 발생
    return aiApplicantComparisonRepository
            .findByMyApplication_IdAndCompetitorApplication_Id(...)
            .map(ComparisonResponse::from)
            .orElseThrow(...);
}
```

**변경 후** — REQUIRES_NEW 독립 트랜잭션으로 위임
```java
// callAiAndSave() 내부
try {
    AiApplicantComparison saved = aiComparisonSaveHelper.trySave(comparison); // REQUIRES_NEW → 독립 트랜잭션
    return ComparisonResponse.from(saved);
} catch (DataIntegrityViolationException e) {
    // 외부 세션은 깨끗 → findBy 정상 동작
    return aiApplicantComparisonRepository
            .findByMyApplication_IdAndCompetitorApplication_Id(...)
            .map(ComparisonResponse::from)
            .orElseThrow(...);
}
```

---

## 6. 검증 방법

`src/test/java/com/thunder11/scuad/scuad/ComparisonConcurrencyTest.java` 실행

- 스레드 2개 동시 `compare()` 호출
- `@MockBean AiServiceClient` + `Thread.sleep(500)`으로 AI 지연 시뮬레이션
- 기대 결과: 성공 2건, 실패 0건, DB 저장 1건
```
[이슈8] AI 비교 race condition 결과
  동시 요청 수  : 2
  성공          : 2
  실패(예외)    : 0
  DB 저장 건수  : 1
```