### PR TITLE
perf: 공고별 채팅방 목록 조회 시 8N+1 쿼리 제거

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/dto/ChatRoomPreloadedData.java
+++ b/src/main/java/com/thunder11/scuad/chat/dto/ChatRoomPreloadedData.java
@@ -1,0 +1,36 @@
+package com.thunder11.scuad.chat.dto;
+
+import com.thunder11.scuad.chat.domain.ChatRoomMember;
+import com.thunder11.scuad.jobposting.domain.AiApplicantEvaluation;
+import com.thunder11.scuad.jobposting.domain.JobApplication;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+// getChatRoomsByJobPosting stream 시작 전 일괄 조회한 공통 데이터 묶음
+//
+// 사용 목적:
+//   convertToSummary, determineJoinEligibility 에 개별 파라미터로 넘기면
+//   메서드 시그니처가 과도하게 길어지므로 record로 묶어 전달
+//
+// 포함 데이터:
+//   - participantCountMap : chatRoomId → 현재 인원 수 (IN 쿼리 1번)
+//   - hostNicknameMap     : userId → 닉네임 (IN 쿼리 1번)
+//   - joinedRoomIds       : 현재 사용자가 참여 중인 chatRoomId Set (IN 쿼리 1번)
+//   - kickedRoomIds       : 현재 사용자가 강퇴된 chatRoomId Set (IN 쿼리 1번)
+//   - jobApplication      : 현재 사용자의 지원서 (stream 밖 1회 조회)
+//   - evaluation          : 현재 사용자의 AI 평가 (stream 밖 1회 조회)
+//   - hasResume           : 현재 사용자의 이력서 제출 여부 (stream 밖 1회 조회)
+//   - otherRoomMember     : 같은 공고 다른 방 참여 여부 (stream 밖 1회 조회)
+public record ChatRoomPreloadedData(
+        Map<Long, Long> participantCountMap,
+        Map<Long, String> hostNicknameMap,
+        Set<Long> joinedRoomIds,
+        Set<Long> kickedRoomIds,
+        JobApplication jobApplication,
+        AiApplicantEvaluation evaluation,
+        boolean hasResume,
+        Optional<ChatRoomMember> otherRoomMember
+) {
+}

--- a/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomMemberRepository.java
@@ -49,6 +49,35 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             "ORDER BY CASE WHEN crm.role = 'HOST' THEN 0 ELSE 1 END, crm.joinedAt ASC")
     java.util.List<ChatRoomMember> findAllActiveMembersByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
+    // 채팅방 ID 목록 기반 현재 인원 수 일괄 조회 (IN 쿼리)
+    // 사용 목적: getChatRoomsByJobPosting, getMyChatRooms 의 N+1 제거
+    //           chatRoomId마다 count 쿼리를 N번 호출하는 대신 IN 쿼리 1번으로 대체
+    @Query("SELECT crm.chatRoomId, COUNT(crm) FROM ChatRoomMember crm " +
+            "WHERE crm.chatRoomId IN :chatRoomIds " +
+            "AND crm.kickedAt IS NULL " +
+            "GROUP BY crm.chatRoomId")
+    java.util.List<Object[]> countByChatRoomIds(@Param("chatRoomIds") java.util.List<Long> chatRoomIds);
+
+    // 특정 사용자가 참여 중인 채팅방 ID 목록 일괄 조회 (IN 쿼리)
+    // 사용 목적: getChatRoomsByJobPosting 의 "이미 참여 중" 확인 N번 → 1번으로 대체
+    @Query("SELECT crm.chatRoomId FROM ChatRoomMember crm " +
+            "WHERE crm.chatRoomId IN :chatRoomIds " +
+            "AND crm.userId = :userId " +
+            "AND crm.kickedAt IS NULL")
+    java.util.List<Long> findJoinedRoomIdsByUserId(
+            @Param("chatRoomIds") java.util.List<Long> chatRoomIds,
+            @Param("userId") Long userId);
+
+    // 특정 사용자가 강퇴된 채팅방 ID 목록 일괄 조회 (IN 쿼리)
+    // 사용 목적: getChatRoomsByJobPosting 의 "강퇴 이력" 확인 N번 → 1번으로 대체
+    @Query("SELECT crm.chatRoomId FROM ChatRoomMember crm " +
+            "WHERE crm.chatRoomId IN :chatRoomIds " +
+            "AND crm.userId = :userId " +
+            "AND crm.kickedAt IS NOT NULL")
+    java.util.List<Long> findKickedRoomIdsByUserId(
+            @Param("chatRoomIds") java.util.List<Long> chatRoomIds,
+            @Param("userId") Long userId);
+
     // 내가 참여 중인 채팅방 목록 조회 (커서 기반 페이징, 최신 참여 순)
     // 테이블 정의서의 idx_chat_members_user 인덱스 활용
     //       (user_id, kicked_at, joined_at DESC)로 최적화된 쿼리

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -2,6 +2,7 @@ package com.thunder11.scuad.chat.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -27,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import com.thunder11.scuad.chat.domain.ChatRoom;
 import com.thunder11.scuad.chat.domain.ChatRoomMember;
 import com.thunder11.scuad.chat.domain.type.MemberRole;
+import com.thunder11.scuad.chat.dto.ChatRoomPreloadedData;
 import com.thunder11.scuad.chat.dto.JoinEligibility;
 import com.thunder11.scuad.chat.dto.request.ChatRoomCreateRequest;
 import com.thunder11.scuad.chat.dto.response.*;
@@ -95,16 +97,11 @@ public class ChatRoomService {
     }
 
     // ChatRoom -> ChatRoomSummaryResponse 변환
-    private ChatRoomSummaryResponse convertToSummary(ChatRoom room, Long userId) {
-        // 현재 인원 수 조회
-        long currentParticipants = chatRoomMemberRepository.countByChatRoomIdAndKickedAtIsNull(room.getChatRoomId());
-
-        // 방장 닉네임 조회
-        String hostNickname = userRepository.findNicknameByUserId(room.getCreatedBy())
-                .orElse("알 수 없음");
-
-        // 입장 가능 여부 및 상태를 한 번에 판단
-        JoinEligibility eligibility = determineJoinEligibility(room, currentParticipants, userId);
+    // 개선: stream 밖에서 미리 조회한 ChatRoomPreloadedData를 받아 DB 재조회 없이 Map 조회만 수행
+    private ChatRoomSummaryResponse convertToSummary(ChatRoom room, Long userId, ChatRoomPreloadedData data) {
+        long currentParticipants = data.participantCountMap().getOrDefault(room.getChatRoomId(), 0L);
+        String hostNickname = data.hostNicknameMap().getOrDefault(room.getCreatedBy(), "알 수 없음");
+        JoinEligibility eligibility = determineJoinEligibility(room, currentParticipants, data);
 
         return ChatRoomSummaryResponse.builder()
                 .chatRoomId(room.getChatRoomId())
@@ -123,13 +120,10 @@ public class ChatRoomService {
     }
 
     // 입장 가능 여부 및 상태를 한 번에 판단
-    private JoinEligibility determineJoinEligibility(ChatRoom room, long currentParticipants, Long userId) {
+    // 개선: Map/Set 조회만 수행 — 기존에는 채팅방마다 최대 6번 DB 조회 발생
+    private JoinEligibility determineJoinEligibility(ChatRoom room, long currentParticipants, ChatRoomPreloadedData data) {
         // 1. 이미 참여 중인지 확인
-        boolean alreadyJoined = chatRoomMemberRepository
-                .findByChatRoomIdAndUserIdAndKickedAtIsNull(room.getChatRoomId(), userId)
-                .isPresent();
-
-        if (alreadyJoined) {
+        if (data.joinedRoomIds().contains(room.getChatRoomId())) {
             return JoinEligibility.unavailable("ALREADY_JOINED");
         }
 
@@ -139,54 +133,36 @@ public class ChatRoomService {
         }
 
         // 3. 강퇴 이력 확인
-        boolean isKicked = chatRoomMemberRepository.existsKickedMember(room.getChatRoomId(), userId);
-        if (isKicked) {
+        if (data.kickedRoomIds().contains(room.getChatRoomId())) {
             return JoinEligibility.unavailable("KICKED");
         }
 
         // 4. 지원서 확인
-        Optional<JobApplication> jobApplicationOpt = jobApplicationRepository
-                .findByUserIdAndJobMasterId(userId, room.getJobMasterId());
-
-        if (jobApplicationOpt.isEmpty()) {
+        if (data.jobApplication() == null) {
             return JoinEligibility.unavailable("NO_APPLICATION");
         }
 
-        Long jobApplicationId = jobApplicationOpt.get().getId();
-
         // 5. 서류 제출 확인 (이력서만 필수, 포트폴리오는 선택)
-        boolean hasResume = applicationDocumentRepository
-                .existsByJobApplicationIdAndDocType(jobApplicationId, ApplicationDocumentType.RESUME);
-
-        if (!hasResume) {
+        if (!data.hasResume()) {
             return JoinEligibility.unavailable("NO_RESUME");
         }
 
-        // 포트폴리오는 선택 제출이므로 검증하지 않음
-
         // 6. AI 점수 확인
-        Optional<AiApplicantEvaluation> evaluationOpt = aiApplicationEvaluationRepository
-                .findByJobApplicationId(jobApplicationId);
-
-        if (evaluationOpt.isEmpty()) {
+        if (data.evaluation() == null) {
             return JoinEligibility.unavailable("NO_SCORE");
         }
 
         // 7. 커트라인 점수 확인
-        Integer myScore = evaluationOpt.get().getOverallScore();
-        if (myScore < room.getCutlineScore()) {
+        if (data.evaluation().getOverallScore() < room.getCutlineScore()) {
             return JoinEligibility.unavailable("CUTLINE_NOT_MET");
         }
 
         // 8. 같은 공고의 다른 방 참여 여부 확인
-        Optional<ChatRoomMember> otherRoomMember = chatRoomMemberRepository
-                .findByJobApplicationIdAndNotKicked(jobApplicationId);
-
-        if (otherRoomMember.isPresent() && !otherRoomMember.get().getChatRoomId().equals(room.getChatRoomId())) {
+        if (data.otherRoomMember().isPresent()
+                && !data.otherRoomMember().get().getChatRoomId().equals(room.getChatRoomId())) {
             return JoinEligibility.unavailable("ALREADY_JOINED_OTHER");
         }
 
-        // 모든 조건 통과
         return JoinEligibility.available();
     }
 
@@ -228,8 +204,76 @@ public class ChatRoomService {
         }
 
         // 5. ChatRoom -> ChatRoomSummaryResponse 변환
+        // 개선: stream 시작 전 공통 데이터를 IN 쿼리로 일괄 조회 후 Map/Set으로 재사용
+        //       기존: 채팅방마다 8번 DB 조회 → 총 4 + (8 × N)번
+        //       개선: stream 밖 IN 쿼리 8번 고정 → 총 4 + 8번 (채팅방 수 무관)
+
+        List<Long> chatRoomIds = chatRooms.stream()
+                .map(ChatRoom::getChatRoomId)
+                .collect(Collectors.toList());
+
+        // 채팅방별 현재 인원 수 (IN 쿼리 1번)
+        Map<Long, Long> participantCountMap = chatRoomMemberRepository.countByChatRoomIds(chatRoomIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        // 방장 닉네임 (IN 쿼리 1번)
+        List<Long> hostIds = chatRooms.stream()
+                .map(ChatRoom::getCreatedBy)
+                .distinct()
+                .collect(Collectors.toList());
+        Map<Long, String> hostNicknameMap = userRepository.findNicknamesByUserIds(hostIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (String) row[1]
+                ));
+
+        // 현재 사용자가 참여 중인 채팅방 ID (IN 쿼리 1번)
+        java.util.Set<Long> joinedRoomIds = new java.util.HashSet<>(
+                chatRoomMemberRepository.findJoinedRoomIdsByUserId(chatRoomIds, userId));
+
+        // 현재 사용자가 강퇴된 채팅방 ID (IN 쿼리 1번)
+        java.util.Set<Long> kickedRoomIds = new java.util.HashSet<>(
+                chatRoomMemberRepository.findKickedRoomIdsByUserId(chatRoomIds, userId));
+
+        // 지원서, AI 평가, 이력서, 다른 방 참여 여부 — userId+jobMasterId 기준으로 채팅방이 달라도 동일
+        // stream 밖에서 1회만 조회하여 N번 반복 조회 제거
+        Optional<JobApplication> jobApplicationOpt = jobApplicationRepository
+                .findByUserIdAndJobMasterId(userId, jobMasterId);
+
+        JobApplication jobApplication = jobApplicationOpt.orElse(null);
+
+        AiApplicantEvaluation evaluation = null;
+        boolean hasResume = false;
+        Optional<ChatRoomMember> otherRoomMember = Optional.empty();
+
+        if (jobApplication != null) {
+            evaluation = aiApplicationEvaluationRepository
+                    .findByJobApplicationId(jobApplication.getId())
+                    .orElse(null);
+            hasResume = applicationDocumentRepository
+                    .existsByJobApplicationIdAndDocType(jobApplication.getId(), ApplicationDocumentType.RESUME);
+            otherRoomMember = chatRoomMemberRepository
+                    .findByJobApplicationIdAndNotKicked(jobApplication.getId());
+        }
+
+        ChatRoomPreloadedData preloadedData = new ChatRoomPreloadedData(
+                participantCountMap,
+                hostNicknameMap,
+                joinedRoomIds,
+                kickedRoomIds,
+                jobApplication,
+                evaluation,
+                hasResume,
+                otherRoomMember
+        );
+
         List<ChatRoomSummaryResponse> summaries = chatRooms.stream()
-                .map(room -> convertToSummary(room, userId))
+                .map(room -> convertToSummary(room, userId, preloadedData))
                 .collect(Collectors.toList());
 
         // 6. 페이징 정보 생성


### PR DESCRIPTION
# [perf] 공고별 채팅방 목록 조회 시 채팅방 수에 비례한 8N+1 쿼리 제거

## 1. 문제 상황

`GET /api/v1/job-postings/{jobMasterId}/chat-rooms` API에서
채팅방 수에 비례해 쿼리가 선형으로 증가하는 8N+1 구조가 존재했습니다.

채팅방 10개 기준 요청 1건당 총 **84번**의 쿼리가 실행됩니다.
```
[고정 쿼리] 4번
├── jobMasterRepository.existsByIdNotDeleted              → 1번
├── jobApplicationRepository.findByUserIdAndJobMasterId   → 1번
├── aiApplicationEvaluationRepository.findByJobApplicationId → 1번
└── chatRoomRepository.findByJobMasterIdWithCursor        → 1번

[채팅방마다 반복] 8N번
├── chatRoomMemberRepository.countByChatRoomIdAndKickedAtIsNull      → N번
├── userRepository.findNicknameByUserId                              → N번
├── chatRoomMemberRepository.findByChatRoomIdAndUserIdAndKickedAtIsNull → N번
├── chatRoomMemberRepository.existsKickedMember                      → N번
├── jobApplicationRepository.findByUserIdAndJobMasterId              → N번
├── applicationDocumentRepository.existsByJobApplicationIdAndDocType → N번
├── aiApplicationEvaluationRepository.findByJobApplicationId         → N번
└── chatRoomMemberRepository.findByJobApplicationIdAndNotKicked      → N번
```

| 채팅방 수 | 총 쿼리 수 |
|---|---|
| 1개 | 12번 |
| 5개 | 44번 |
| 10개 | 84번 |

<img width="1708" height="940" alt="Image" src="https://github.com/user-attachments/assets/f3abde10-31e4-4036-9f3f-b5f6aae13838" />

---

## 2. 원인 분석

핵심 문제는 두 가지입니다.

**첫째, `determineJoinEligibility`가 채팅방마다 개별 호출되는 구조입니다.**
입장 가능 여부 판단을 위해 최대 6개의 쿼리를 채팅방마다 반복 실행합니다.

**둘째, 같은 공고의 채팅방이면 결과가 동일한 쿼리가 N번 반복됩니다.**
`jobApplicationRepository.findByUserIdAndJobMasterId(userId, jobMasterId)`는
`getMyScore()`에서 1회 실행된 후, stream 내 `determineJoinEligibility()`에서
동일한 `userId + jobMasterId` 조합으로 N번 재실행됩니다.
같은 공고의 채팅방이면 `userId`와 `jobMasterId`가 바뀌지 않으므로 완전히 불필요한 낭비입니다.

두 문제의 공통 원인은 **채팅방 수와 무관하게 고정된 값임에도 stream 안에서 반복 조회하는 구조**입니다.

---

## 3. 해결 방법

**공통 데이터 일괄 조회 + Map/Set 캐싱** 방식을 채택했습니다.

### 채택 이유

현재 엔티티 설계가 `ChatRoom`, `ChatRoomMember` 모두 연관관계 없이 Long FK만 보유하는 구조라
Fetch Join, @BatchSize, QueryDSL DTO 프로젝션 모두 적용이 불가하거나 복잡도가 과도합니다.
(자세한 후보 비교는 개선 리스트업 문서 참고)

stream 시작 전 chatRoomId 목록 기반 IN 쿼리로 채팅방별 데이터를 일괄 조회하고,
userId + jobMasterId 기준으로 채팅방이 달라도 동일한 데이터는 stream 밖에서 1회만 조회합니다.
결과를 `ChatRoomPreloadedData`로 묶어 stream에 전달하면 내부에서는 Map/Set 조회만 수행합니다.
```
// 개선 후 흐름
// stream 시작 전 — IN 쿼리 4번
chatRoomMemberRepository.countByChatRoomIds(chatRoomIds)               // 인원 수
userRepository.findNicknamesByUserIds(hostIds)                         // 방장 닉네임
chatRoomMemberRepository.findJoinedRoomIdsByUserId(chatRoomIds, userId) // 참여 중 여부
chatRoomMemberRepository.findKickedRoomIdsByUserId(chatRoomIds, userId) // 강퇴 이력

// stream 시작 전 — 고정 데이터 4번 (userId+jobMasterId 기준, 채팅방 달라도 동일)
jobApplicationRepository.findByUserIdAndJobMasterId(userId, jobMasterId)
aiApplicationEvaluationRepository.findByJobApplicationId(applicationId)
applicationDocumentRepository.existsByJobApplicationIdAndDocType(...)
chatRoomMemberRepository.findByJobApplicationIdAndNotKicked(applicationId)

// stream 내부 — DB 쿼리 없음, Map/Set 조회만 수행
chatRooms.stream().map(room -> convertToSummary(room, userId, preloadedData))
```

쿼리 수: `4 + (8 × N)` → `4 + 8` (채팅방 수 무관 고정)

---

## 4. 변경 범위

### `ChatRoomMemberRepository` — IN 쿼리 3개 추가
```java
// 채팅방별 현재 인원 수 일괄 조회
@Query("SELECT crm.chatRoomId, COUNT(crm) FROM ChatRoomMember crm " +
        "WHERE crm.chatRoomId IN :chatRoomIds AND crm.kickedAt IS NULL " +
        "GROUP BY crm.chatRoomId")
List<Object[]> countByChatRoomIds(@Param("chatRoomIds") List<Long> chatRoomIds);

// 참여 중인 채팅방 ID 목록 일괄 조회
@Query("SELECT crm.chatRoomId FROM ChatRoomMember crm " +
        "WHERE crm.chatRoomId IN :chatRoomIds AND crm.userId = :userId AND crm.kickedAt IS NULL")
List<Long> findJoinedRoomIdsByUserId(@Param("chatRoomIds") List<Long> chatRoomIds, @Param("userId") Long userId);

// 강퇴된 채팅방 ID 목록 일괄 조회
@Query("SELECT crm.chatRoomId FROM ChatRoomMember crm " +
        "WHERE crm.chatRoomId IN :chatRoomIds AND crm.userId = :userId AND crm.kickedAt IS NOT NULL")
List<Long> findKickedRoomIdsByUserId(@Param("chatRoomIds") List<Long> chatRoomIds, @Param("userId") Long userId);
```

### `ChatRoomPreloadedData` (신규 record)

- stream 전달용 값 객체
- 8개 필드(`participantCountMap`, `hostNicknameMap`, `joinedRoomIds`, `kickedRoomIds`, `jobApplication`, `evaluation`, `hasResume`, `otherRoomMember`)를 불변으로 묶어 전달
- record 사용 이유: `convertToSummary`, `determineJoinEligibility` 두 메서드에 공통으로 전달할 데이터가 8개로 많아, 개별 파라미터로 넘기면 시그니처가 과도하게 길어지기 때문

### `ChatRoomService`

- `getChatRoomsByJobPosting`: stream 시작 전 IN 쿼리 일괄 조회 + `ChatRoomPreloadedData` 구성
- `convertToSummary`: `ChatRoomPreloadedData`를 파라미터로 받아 Map 조회만 수행
- `determineJoinEligibility`: `ChatRoomPreloadedData`를 파라미터로 받아 Map/Set 조회만 수행

---

## 5. 검증 방법

베이스라인과 동일 조건으로 k6 재측정

- VU: 10명, 지속 시간: 30초, 요청 간격: 1초
- 대상: `GET /api/v1/job-postings/1/chat-rooms?size=10`
- 테스트 데이터: job_master_id=1에 채팅방 10개
