### PR TITLE
perf: getMyChatRooms 4N+1 쿼리 개선

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/thunder11/scuad/chat/repository/ChatMessageRepository.java
@@ -38,4 +38,19 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     );
 
     Optional<ChatMessage> findTopByChatRoomIdOrderBySentAtDesc(Long chatRoomId);
+
+    // 채팅방 ID 목록별 마지막 메시지 일괄 조회 (greatest-n-per-group, IN + 서브쿼리)
+    // 사용 목적: getMyChatRooms 에서 stream 내 findTopBy...() N번 → 1번으로 대체
+    // 설계 근거: 채팅방마다 가장 최근 메시지 1건만 가져오는 greatest-n-per-group 문제를
+    //           JPQL 상관 서브쿼리(MAX sentAt 매칭)로 표현하여 QueryDSL/Native 의존 없이 해결
+    //           sentAt 동일 메시지가 여러 건인 엣지 케이스는 미리보기 목적상 허용 범위로 판단
+    @Query("""
+            SELECT cm FROM ChatMessage cm
+            WHERE cm.chatRoomId IN :chatRoomIds
+              AND cm.sentAt = (
+                  SELECT MAX(cm2.sentAt) FROM ChatMessage cm2
+                  WHERE cm2.chatRoomId = cm.chatRoomId
+              )
+            """)
+    List<ChatMessage> findLastMessagesByChatRoomIds(@Param("chatRoomIds") List<Long> chatRoomIds);
 }

--- a/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomRepository.java
@@ -52,4 +52,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
                         "AND cr.deletedAt IS NULL " +
                         "GROUP BY cr.jobMasterId")
         List<Object[]> countActiveRoomsByJobMasterIds(@Param("jobMasterIds") List<Long> jobMasterIds);
+
+        // 채팅방 ID 목록으로 채팅방 일괄 조회 (IN 쿼리)
+        // 사용 목적: getMyChatRooms 에서 stream 내 findById() N번 → IN 쿼리 1번으로 대체
+        //           멤버십 목록에서 chatRoomId만 먼저 추출한 뒤 한 번에 조회하여 Map으로 캐싱
+        @Query("SELECT cr FROM ChatRoom cr WHERE cr.chatRoomId IN :chatRoomIds AND cr.deletedAt IS NULL")
+        List<ChatRoom> findAllByChatRoomIdIn(@Param("chatRoomIds") List<Long> chatRoomIds);
 }

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -708,6 +708,7 @@ public class ChatRoomService {
     // 내가 참여 중인 채팅방 목록 조회
     // 사용자는 본인이 참여 중인 채팅방 리스트를 확인할 수 있어야 함
     // 최신 참여 순으로 정렬하여 활동성 높은 채팅방을 우선 표시
+    // 개선: stream 내 4번 반복 조회(4N+1) → chatRoomId 기반 IN 쿼리 4번 고정으로 대체
     public MyChatRoomListResponse getMyChatRooms(
             Long userId,
             Long cursor,
@@ -731,33 +732,89 @@ public class ChatRoomService {
                 ? members.subList(0, size)
                 : members;
 
-        // 3. 각 멤버십에 대해 채팅방 정보 조회 및 DTO 변환
+        if (actualMembers.isEmpty()) {
+            return MyChatRoomListResponse.builder()
+                    .chatRooms(List.of())
+                    .pagination(PaginationResponse.builder()
+                            .nextCursor(null)
+                            .hasNext(false)
+                            .size(0)
+                            .build())
+                    .build();
+        }
+
+        // 3. chatRoomId 목록 추출 — 이후 4개 IN 쿼리의 공통 키
+        List<Long> chatRoomIds = actualMembers.stream()
+                .map(ChatRoomMember::getChatRoomId)
+                .collect(Collectors.toList());
+
+        // ── IN 쿼리 일괄 조회 (채팅방 수와 무관하게 각 1번씩, 총 4번) ──────────────
+
+        // 3-1. 채팅방 정보 일괄 조회
+        // 개선 근거: stream 내 findById() N번 → IN 쿼리 1번
+        Map<Long, ChatRoom> chatRoomMap = chatRoomRepository
+                .findAllByChatRoomIdIn(chatRoomIds)
+                .stream()
+                .collect(Collectors.toMap(ChatRoom::getChatRoomId, cr -> cr));
+
+        // 3-2. 채팅방별 현재 인원 수 일괄 조회
+        // 개선 근거: countByChatRoomIdAndKickedAtIsNull() N번 → IN 쿼리 1번 (8N+1 작업 시 추가된 메서드 재사용)
+        Map<Long, Long> participantCountMap = chatRoomMemberRepository
+                .countByChatRoomIds(chatRoomIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        // 3-3. 방장 닉네임 일괄 조회
+        // 개선 근거: findNicknameByUserId() N번 → IN 쿼리 1번 (8N+1 작업 시 추가된 메서드 재사용)
+        List<Long> hostIds = chatRoomMap.values().stream()
+                .map(ChatRoom::getCreatedBy)
+                .distinct()
+                .collect(Collectors.toList());
+        Map<Long, String> hostNicknameMap = userRepository
+                .findNicknamesByUserIds(hostIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (String) row[1]
+                ));
+
+        // 3-4. 채팅방별 마지막 메시지 일괄 조회
+        // 개선 근거: findTopByChatRoomIdOrderBySentAtDesc() N번 → IN + 서브쿼리 1번
+        Map<Long, ChatMessage> lastMessageMap = chatMessageRepository
+                .findLastMessagesByChatRoomIds(chatRoomIds)
+                .stream()
+                .collect(Collectors.toMap(ChatMessage::getChatRoomId, msg -> msg));
+
+        // ─────────────────────────────────────────────────────────────────────
+        // 4. stream 내에서는 Map 조회만 수행 (DB 쿼리 0번)
+        // 개선 근거: 기존에는 채팅방마다 4번 DB 조회 발생 → Map.get()으로 대체하여 쿼리 제거
         List<MyChatRoomResponse> chatRoomResponses = actualMembers.stream()
                 .map(member -> {
-                    // 채팅방 정보 조회
-                    ChatRoom chatRoom = chatRoomRepository.findById(member.getChatRoomId())
-                            .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+                    ChatRoom chatRoom = chatRoomMap.get(member.getChatRoomId());
+                    if (chatRoom == null) {
+                        // 조회 시점과 삭제 시점 사이 race condition 방어 처리
+                        log.warn("멤버십은 있으나 채팅방을 찾을 수 없음: chatRoomId={}", member.getChatRoomId());
+                        return null;
+                    }
 
-                    // 현재 인원 수 조회
-                    long currentParticipants = chatRoomMemberRepository
-                            .countByChatRoomIdAndKickedAtIsNull(chatRoom.getChatRoomId());
+                    long currentParticipants = participantCountMap
+                            .getOrDefault(chatRoom.getChatRoomId(), 0L);
 
-                    // 방장 닉네임 조회
-                    String hostNickname = userRepository.findNicknameByUserId(chatRoom.getCreatedBy())
-                            .orElse("알 수 없음");
+                    String hostNickname = hostNicknameMap
+                            .getOrDefault(chatRoom.getCreatedBy(), "알 수 없음");
 
-                    // 마지막 메시지 조회 (선택)
-                    Optional<ChatMessage> lastMessageOpt = chatMessageRepository
-                            .findTopByChatRoomIdOrderBySentAtDesc(chatRoom.getChatRoomId());
+                    ChatMessage lastMessage = lastMessageMap.get(chatRoom.getChatRoomId());
 
-                    String lastMessagePreview = lastMessageOpt
+                    String lastMessagePreview = Optional.ofNullable(lastMessage)
                             .map(msg -> {
                                 if (msg.getMessageType().name().equals("FILE")) {
                                     return "[파일]";
                                 } else if (msg.getMessageType().name().equals("SYSTEM")) {
                                     return msg.getContent();
                                 } else {
-                                    // TEXT 메시지는 50자로 제한
                                     String content = msg.getContent();
                                     return content.length() > 50
                                             ? content.substring(0, 50) + "..."
@@ -766,7 +823,7 @@ public class ChatRoomService {
                             })
                             .orElse(null);
 
-                    LocalDateTime lastMessageAt = lastMessageOpt
+                    LocalDateTime lastMessageAt = Optional.ofNullable(lastMessage)
                             .map(ChatMessage::getSentAt)
                             .orElse(null);
 
@@ -787,18 +844,19 @@ public class ChatRoomService {
                             .joinedAt(member.getJoinedAt())
                             .build();
                 })
+                .filter(response -> response != null)
                 .collect(Collectors.toList());
 
-        // 4. 다음 커서 계산 (마지막 멤버의 chatRoomMemberId)
+        // 5. 다음 커서 계산 (마지막 멤버의 chatRoomMemberId)
         Long nextCursor = hasNext && !actualMembers.isEmpty()
                 ? actualMembers.get(actualMembers.size() - 1).getChatRoomMemberId()
                 : null;
 
-        // 5. 페이징 정보 생성
+        // 6. 페이징 정보 생성
         PaginationResponse pagination = PaginationResponse.builder()
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
-                .size(actualMembers.size())
+                .size(chatRoomResponses.size())
                 .build();
 
         log.info("내 채팅방 목록 조회 완료: userId={}, 조회된 방 수={}, hasNext={}",


### PR DESCRIPTION
# [perf] 내 채팅방 목록 조회 시 채팅방 수에 비례한 4N+1 쿼리 제거

## 1. 문제 상황

`GET /api/v1/users/me/chat-rooms` API에서
채팅방 수에 비례해 쿼리가 선형으로 증가하는 4N+1 구조가 존재했습니다.

채팅방 21개(size=20) 기준 요청 1건당 총 **85번**의 쿼리가 실행됩니다.
```
[고정 쿼리] 1번
└── chatRoomMemberRepository.findMyChatRooms(userId, cursor, pageable)  → 1번

[채팅방마다 반복] 4N번
├── chatRoomRepository.findById(chatRoomId)                             → N번
├── chatRoomMemberRepository.countByChatRoomIdAndKickedAtIsNull         → N번
├── userRepository.findNicknameByUserId(createdBy)                      → N번
└── chatMessageRepository.findTopByChatRoomIdOrderBySentAtDesc          → N번
```

| 채팅방 수 | 총 쿼리 수 |
|---|---|
| 1개 | 5번 |
| 10개 | 41번 |
| 21개 | 85번 |

---

## 2. 원인 분석

문제의 핵심은 **멤버십 목록 조회 후 각 채팅방 데이터를 stream 안에서 개별 조회하는 구조**입니다.

`ChatRoomMember`는 `chatRoomId`, `userId`, `jobApplicationId`를 모두 Long FK로만 보유하며
JPA 연관관계(`@ManyToOne`)가 없습니다. 이 구조로 인해 stream 내 `findById()` 호출 시
Hibernate가 연관 엔티티를 자동으로 JOIN 조회할 수 없어 N번의 개별 쿼리가 발생합니다.

4가지 조회(`chatRoom`, `participantCount`, `hostNickname`, `lastMessage`) 모두
채팅방마다 반복되므로 채팅방 수가 늘수록 응답 시간이 선형으로 증가합니다.

---

## 3. 해결 방법

**chatRoomId 목록 기반 IN 쿼리 일괄 조회 + Map 캐싱** 방식을 채택했습니다.

### 채택 이유

현재 엔티티 설계가 연관관계 없이 Long FK만 보유하는 구조라
Fetch Join, @BatchSize, QueryDSL DTO 프로젝션 모두 적용이 불가하거나 복잡도가 과도합니다.
(자세한 후보 비교는 이슈 문서 참고)

멤버십 목록에서 `chatRoomId`를 먼저 추출한 뒤
4종 데이터를 각각 IN 쿼리 1번씩 일괄 조회하여 Map으로 만들고,
stream 내에서는 Map.get() 조회만 수행하도록 구조를 변경했습니다.

마지막 메시지 조회(`greatest-n-per-group`)는 QueryDSL 윈도우 함수 방식 대신
JPQL 상관 서브쿼리(MAX sentAt 매칭)로 표현하여 Native Query 의존성 없이 해결했습니다.
```
// 개선 후 흐름

// 멤버십 목록 조회 — 1번 (기존과 동일)
chatRoomMemberRepository.findMyChatRooms(userId, cursor, pageable)

// chatRoomId 목록 추출 후 IN 쿼리 4번 일괄 조회
chatRoomRepository.findAllByChatRoomIdIn(chatRoomIds)                    // 채팅방 정보
chatRoomMemberRepository.countByChatRoomIds(chatRoomIds)                 // 현재 인원 수
userRepository.findNicknamesByUserIds(hostIds)                           // 방장 닉네임
chatMessageRepository.findLastMessagesByChatRoomIds(chatRoomIds)         // 마지막 메시지

// stream 내부 — DB 쿼리 없음, Map.get()만 수행
actualMembers.stream().map(member -> { chatRoomMap.get(...); ... })
```

쿼리 수: `1 + (4 × N)` → `1 + 4` (채팅방 수 무관 고정)

---

## 4. 변경 범위

### `ChatRoomRepository` — IN 쿼리 1개 추가
```java
// 채팅방 ID 목록으로 채팅방 일괄 조회
// stream 내 findById() N번 → IN 쿼리 1번으로 대체
@Query("SELECT cr FROM ChatRoom cr WHERE cr.chatRoomId IN :chatRoomIds AND cr.deletedAt IS NULL")
List<ChatRoom> findAllByChatRoomIdIn(@Param("chatRoomIds") List<Long> chatRoomIds);
```

### `ChatMessageRepository` — IN 쿼리 1개 추가
```java
// 채팅방별 마지막 메시지 일괄 조회 (greatest-n-per-group)
// findTopByChatRoomIdOrderBySentAtDesc() N번 → JPQL 상관 서브쿼리 1번으로 대체
// QueryDSL 윈도우 함수 방식은 Native Query 의존성이 생기므로 JPQL로 해결
@Query("""
        SELECT cm FROM ChatMessage cm
        WHERE cm.chatRoomId IN :chatRoomIds
          AND cm.sentAt = (
              SELECT MAX(cm2.sentAt) FROM ChatMessage cm2
              WHERE cm2.chatRoomId = cm.chatRoomId
          )
        """)
List<ChatMessage> findLastMessagesByChatRoomIds(@Param("chatRoomIds") List<Long> chatRoomIds);
```

### `ChatRoomService.getMyChatRooms` — 핵심 구조 변경

- stream 시작 전 `chatRoomIds` 추출 후 IN 쿼리 4번 일괄 조회
- 결과를 `Map<Long, ChatRoom>`, `Map<Long, Long>`, `Map<Long, String>`, `Map<Long, ChatMessage>` 4개의 Map으로 캐싱
- stream 내부에서는 Map.get() / getOrDefault()만 수행
- `countByChatRoomIds`, `findNicknamesByUserIds`는 8N+1 개선 작업 시 추가된 메서드 재사용
- 빈 목록 조기 반환 로직 추가 (불필요한 IN 쿼리 방어)

---

## 5. 검증 방법

베이스라인과 동일 조건으로 k6 재측정 예정 (별도 테스트 브랜치에서 진행)

- VU: 10명, 지속 시간: 30초, 요청 간격: 1초
- 대상: `GET /api/v1/users/me/chat-rooms?size=20`
- 조회 주체: userId=1 (채팅방 21개 참여 상태)
- 필요 시드: V2 + V4

---