### PR TITLE
Fix/chatroom polling websocket

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.10.0'
 
     // JWT

--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -149,18 +149,17 @@ public class ChatRoomController {
     public ApiResponse<ChatMessageListResponse> getMessages(
             @PathVariable Long chatRoomId,
             @RequestParam(required = false) Long cursor,
-            @RequestParam(required = false) Long since,
             @RequestParam(defaultValue = "50") int size,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        log.info("GET /api/v1/chat-rooms/{}/messages - cursor={}, since={}, size={}, userId={}",
-                chatRoomId, cursor, since, size, userPrincipal.getUserId());
+        // WebSocket 전환으로 since 파라미터 제거 — 신규 메시지는 WebSocket으로 수신
+        log.info("GET /api/v1/chat-rooms/{}/messages - cursor={}, size={}, userId={}",
+                chatRoomId, cursor, size, userPrincipal.getUserId());
 
         ChatMessageListResponse response = chatMessageService.getMessages(
                 chatRoomId,
                 userPrincipal.getUserId(),
                 cursor,
-                since,
                 size
         );
 

--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -228,6 +228,11 @@ public class ChatRoomController {
                 request
         );
 
+        // 트랜잭션 커밋 완료 후 브로드캐스트
+        // sendMessage() 리턴 = 트랜잭션 커밋 완료 시점
+        // 이 시점 이후에 broadcast해야 수신 클라이언트의 GET /messages에서 메시지 누락 없음
+        chatMessageService.broadcast(chatRoomId, response);
+
         return ApiResponse.of(
                 HttpStatus.CREATED.value(),
                 "MESSAGE_SENT",

--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -186,7 +186,17 @@ public class ChatRoomController {
                 chatRoomId, messageType, content, (file != null), userPrincipal.getUserId());
 
         // MessageType 변환
-        MessageType msgType = MessageType.valueOf(messageType.toUpperCase());
+        // 잘못된 값(예: "TEXT" 아닌 임의 문자열) 입력 시 valueOf()가 IllegalArgumentException을 던져
+        // GlobalExceptionHandler가 처리하지 못하면 500이 반환되므로 명시적으로 400 처리
+        MessageType msgType;
+        try {
+            msgType = MessageType.valueOf(messageType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("유효하지 않은 messageType 입력: {}", messageType);
+            throw new com.thunder11.scuad.common.exception.ApiException(
+                    com.thunder11.scuad.common.exception.ErrorCode.INVALID_INPUT_VALUE
+            );
+        }
         
         Long fileId = null;
         

--- a/src/main/java/com/thunder11/scuad/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/thunder11/scuad/chat/repository/ChatMessageRepository.java
@@ -26,17 +26,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             Pageable pageable
     );
 
-    // 폴링을 위한 최신 메시지 조회 (특정 messageId 이후의 메시지)
-    @Query("SELECT cm FROM ChatMessage cm " +
-            "WHERE cm.chatRoomId = :chatRoomId " +
-            "AND cm.deletedAt IS NULL " +
-            "AND cm.messageId > :afterMessageId " +
-            "ORDER BY cm.messageId ASC")
-    List<ChatMessage> findNewMessagesSince(
-            @Param("chatRoomId") Long chatRoomId,
-            @Param("afterMessageId") Long afterMessageId
-    );
-
     Optional<ChatMessage> findTopByChatRoomIdOrderBySentAtDesc(Long chatRoomId);
 
     // 채팅방 ID 목록별 마지막 메시지 일괄 조회 (greatest-n-per-group, IN + 서브쿼리)

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
@@ -94,7 +94,8 @@ public class ChatMessageService {
                 .build();
     }
 
-    // 채팅 메시지 목록 조회 (커서 기반 페이징 + 폴링)
+    // 채팅 메시지 목록 조회 (커서 기반 페이징) — 입장 시 과거 메시지 로드 전용
+    // 신규 메시지 수신은 WebSocket 구독(/topic/chat-rooms/{id})으로 처리
     public ChatMessageListResponse getMessages(
             Long chatRoomId,
             Long userId,

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
@@ -290,12 +290,21 @@ public class ChatMessageService {
 
         ChatMessageResponse result = convertToResponse(savedMessage, nicknameMap, fileInfoMap);
 
-        // WebSocket 브로드캐스트
-        // 해당 채팅방을 구독 중인 모든 클라이언트에게 새 메시지를 즉시 push
-        // 클라이언트는 /topic/chat-rooms/{chatRoomId} 를 구독하고 있어야 수신 가능
-        messagingTemplate.convertAndSend("/topic/chat-rooms/" + chatRoomId, result);
-        log.info("WebSocket 브로드캐스트 완료: chatRoomId={}, messageId={}", chatRoomId, savedMessage.getMessageId());
-
         return result;
+    }
+
+    // WebSocket 브로드캐스트 — @Transactional 밖에서 호출해야 함
+    //
+    // 분리 근거:
+    //   sendMessage()는 @Transactional 메서드이므로, 메서드 내부에서 convertAndSend()를 호출하면
+    //   트랜잭션 커밋 전에 브로드캐스트가 발생한다.
+    //   이 경우 메시지를 받은 클라이언트가 즉시 GET /messages를 호출하면
+    //   아직 커밋되지 않은 데이터를 조회하여 메시지가 누락되는 레이스 컨디션이 발생한다.
+    //
+    // 호출 위치: ChatRoomController.sendMessage() — sendMessage() 리턴 후 즉시 호출
+    //   sendMessage() 리턴 시점 = 트랜잭션 커밋 완료 시점이므로 레이스 컨디션 해소
+    public void broadcast(Long chatRoomId, ChatMessageResponse result) {
+        messagingTemplate.convertAndSend("/topic/chat-rooms/" + chatRoomId, result);
+        log.info("WebSocket 브로드캐스트 완료: chatRoomId={}, messageId={}", chatRoomId, result.getMessageId());
     }
 }

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
@@ -13,6 +13,7 @@ import com.thunder11.scuad.file.repository.FileObjectRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +42,7 @@ public class ChatMessageService {
     private final UserRepository userRepository;
     private final FileObjectRepository fileObjectRepository;
     private final S3FileManagementService s3FileManagementService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     private record FileInfo(Long fileId, String fileName, String contentType, Long fileSize) {
     }
@@ -97,11 +99,10 @@ public class ChatMessageService {
             Long chatRoomId,
             Long userId,
             Long cursor,
-            Long since,
             int size
     ) {
-        log.info("메시지 목록 조회 시작: chatRoomId={}, userId={}, cursor={}, since={}, size={}",
-                chatRoomId, userId, cursor, since, size);
+        log.info("메시지 목록 조회 시작: chatRoomId={}, userId={}, cursor={}, size={}",
+                chatRoomId, userId, cursor, size);
 
         // 1. 채팅방 존재 확인
         chatRoomRepository.findByIdNotDeleted(chatRoomId)
@@ -117,47 +118,29 @@ public class ChatMessageService {
             throw new ApiException(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
         }
 
-        // 3. since와 cursor 동시 사용 검증
-        if (since != null && cursor != null) {
-            log.warn("since와 cursor를 동시에 사용할 수 없습니다: chatRoomId={}, userId={}", chatRoomId, userId);
-            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE);
+
+        // WebSocket 전환으로 since 기반 폴링 제거
+        // 신규 메시지 수신은 WebSocket 구독(/topic/chat-rooms/{id})으로 처리
+        // 이 API는 채팅방 입장 시 과거 메시지 로드(커서 페이징) 용도로만 사용
+        List<ChatMessage> messages = chatMessageRepository.findMessagesByChatRoomIdWithCursor(
+                chatRoomId,
+                cursor,
+                PageRequest.of(0, size + 1)
+        );
+        log.info("과거 메시지 조회 완료: {}개", messages.size());
+
+        // 페이징 정보 계산
+        boolean hasNext = messages.size() > size;
+        if (hasNext) {
+            messages = messages.subList(0, size);
         }
 
-        List<ChatMessage> messages;
-        boolean isPolling = (since != null);
-
-        // 4. 폴링 요청인지 과거 메시지 로드인지 구분
-        if (isPolling) {
-            // 폴링: since 이후의 최신 메시지 조회
-            messages = chatMessageRepository.findNewMessagesSince(chatRoomId, since);
-            log.info("폴링 메시지 조회 완료: {}개", messages.size());
-        } else {
-            // 과거 메시지 로드: 커서 기반 페이징
-            messages = chatMessageRepository.findMessagesByChatRoomIdWithCursor(
-                    chatRoomId,
-                    cursor,
-                    PageRequest.of(0, size + 1)
-            );
-            log.info("과거 메시지 조회 완료: {}개", messages.size());
+        Long nextCursor = null;
+        if (hasNext && !messages.isEmpty()) {
+            nextCursor = messages.get(messages.size() - 1).getMessageId();
         }
 
-        // 5. 페이징 정보 계산 (폴링이 아닐 때만)
-        PaginationResponse pagination = null;
-
-        if (!isPolling) {
-            boolean hasNext = messages.size() > size;
-            if (hasNext) {
-                messages = messages.subList(0, size);
-            }
-
-            Long nextCursor = null;
-            if (hasNext && !messages.isEmpty()) {
-                nextCursor = messages.get(messages.size() - 1).getMessageId();
-            }
-
-            pagination = PaginationResponse.of(nextCursor, hasNext, messages.size());
-        }
-
+        PaginationResponse pagination = PaginationResponse.of(nextCursor, hasNext, messages.size());
         // 6. 발신자 닉네임 일괄 조회 (N+1 문제 해결)
         List<Long> senderIds = messages.stream()
                 .map(ChatMessage::getSenderId)
@@ -204,7 +187,7 @@ public class ChatMessageService {
                 .map(message -> convertToResponse(message, finalNicknameMap, finalFileInfoMap))
                 .collect(Collectors.toList());
 
-        log.info("메시지 목록 조회 완료: 총 {}개, 폴링={}", messageResponses.size(), isPolling);
+        log.info("메시지 목록 조회 완료: 총 {}개", messageResponses.size());
 
         return ChatMessageListResponse.of(messageResponses, pagination);
     }
@@ -304,6 +287,14 @@ public class ChatMessageService {
             }
         }
 
-        return convertToResponse(savedMessage, nicknameMap, fileInfoMap);
+        ChatMessageResponse result = convertToResponse(savedMessage, nicknameMap, fileInfoMap);
+
+        // WebSocket 브로드캐스트
+        // 해당 채팅방을 구독 중인 모든 클라이언트에게 새 메시지를 즉시 push
+        // 클라이언트는 /topic/chat-rooms/{chatRoomId} 를 구독하고 있어야 수신 가능
+        messagingTemplate.convertAndSend("/topic/chat-rooms/" + chatRoomId, result);
+        log.info("WebSocket 브로드캐스트 완료: chatRoomId={}, messageId={}", chatRoomId, savedMessage.getMessageId());
+
+        return result;
     }
 }

--- a/src/main/java/com/thunder11/scuad/chat/websocket/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/thunder11/scuad/chat/websocket/WebSocketAuthInterceptor.java
@@ -1,0 +1,89 @@
+package com.thunder11.scuad.chat.websocket;
+
+import com.thunder11.scuad.auth.util.JwtProvider;
+import com.thunder11.scuad.common.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+// WebSocket 핸드셰이크 시점의 JWT 인증 인터셉터
+// WebSocket은 한 번 연결되면 HTTP 헤더를 다시 보낼 수 없기 때문에
+// 최초 연결(핸드셰이크) 시점에 JWT를 검증하고 userId를 세션에 저장해둠
+// 이후 @MessageMapping 핸들러에서 세션에 저장된 userId를 꺼내 사용
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthInterceptor implements HandshakeInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    // 핸드셰이크 전 처리 — JWT 검증 및 userId 세션 저장
+    // 클라이언트는 연결 URL 쿼리 파라미터로 토큰 전달
+    // 예: ws://localhost:8080/ws?token=eyJhbGci...
+    // SockJS 환경에서는 HTTP 헤더 설정이 제한적이라 쿼리 파라미터 방식 사용
+    // return true: 연결 허용 / return false: 연결 거절
+    @Override
+    public boolean beforeHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes
+    ) {
+        try {
+            // 쿼리 파라미터에서 token 추출
+            String query = request.getURI().getQuery();
+            if (query == null || !query.contains("token=")) {
+                log.warn("WebSocket 연결 거절 — 토큰 없음: uri={}", request.getURI());
+                return false;
+            }
+
+            // token= 이후 값 파싱
+            String token = null;
+            for (String param : query.split("&")) {
+                if (param.startsWith("token=")) {
+                    token = param.substring("token=".length());
+                    break;
+                }
+            }
+
+            if (token == null || token.isBlank()) {
+                log.warn("WebSocket 연결 거절 — 토큰 값 없음");
+                return false;
+            }
+
+            // JWT 유효성 검증 (만료/위조 시 ApiException 발생)
+            jwtProvider.validateToken(token);
+
+            // userId 추출 후 WebSocket 세션에 저장
+            // 세션에 저장해두면 이후 메시지 처리 시 DB 조회 없이 바로 사용 가능
+            Long userId = jwtProvider.getUserIdFromToken(token);
+            attributes.put("userId", userId);
+
+            log.info("WebSocket 핸드셰이크 성공: userId={}", userId);
+            return true;
+
+        } catch (ApiException e) {
+            log.warn("WebSocket 연결 거절 — 토큰 인증 실패: {}", e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.error("WebSocket 핸드셰이크 중 예외 발생", e);
+            return false;
+        }
+    }
+
+    // 핸드셰이크 후 처리 — 현재는 별도 처리 없음
+    @Override
+    public void afterHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Exception exception
+    ) {
+    }
+}

--- a/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
+++ b/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
@@ -96,6 +96,11 @@ public class SecurityConfig {
                         .requestMatchers("/api/internal/**").permitAll()
                         // Actuator 엔드포인트 퍼블릭 허용
                         .requestMatchers("/actuator/**").permitAll()
+                        // WebSocket 핸드셰이크 경로 허용
+                        // /ws/** 로 설정하는 이유: SockJS가 /ws/info, /ws/{serverId}/{sessionId}/websocket 등
+                        // 하위 경로를 추가로 사용하기 때문에 /** 패턴으로 전체 허용
+                        // 실제 인증은 SecurityConfig가 아니라 WebSocketAuthInterceptor에서 처리
+                        .requestMatchers("/ws/**").permitAll()
                         // 채용공고 조회는 퍼블릭 허용 (임시)
                         .requestMatchers("/api/v1/job-postings/**").permitAll()
                         .requestMatchers("/api/v1/job-postings").permitAll()

--- a/src/main/java/com/thunder11/scuad/common/config/WebSocketConfig.java
+++ b/src/main/java/com/thunder11/scuad/common/config/WebSocketConfig.java
@@ -1,0 +1,36 @@
+package com.thunder11.scuad.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+// WebSocket + STOMP 설정
+// 클라이언트가 /ws 로 연결하면 STOMP 프로토콜로 메시지를 주고받을 수 있음
+// 폴링(2초마다 GET 반복) → WebSocket(서버가 변경 시에만 push) 전환을 위해 추가
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    // 메시지 브로커 설정
+    // enableSimpleBroker("/topic"): /topic/chat-rooms/{id} 를 구독한 클라이언트들에게 메시지 브로드캐스트
+    // setApplicationDestinationPrefixes("/app"): 클라이언트가 서버로 메시지 보낼 때 사용하는 prefix
+    //   예) 클라이언트가 /app/chat-rooms/1/messages 로 전송 → @MessageMapping("/chat-rooms/1/messages") 가 수신
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    // STOMP 엔드포인트 등록
+    // addEndpoint("/ws"): 클라이언트가 WebSocket 연결을 맺는 URL (ws://서버주소/ws)
+    // setAllowedOriginPatterns("*"): CORS 허용 (운영에서는 프론트엔드 도메인으로 제한 필요)
+    // withSockJS(): WebSocket 미지원 환경에서 자동으로 Long Polling 등으로 폴백
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}

--- a/src/main/java/com/thunder11/scuad/common/config/WebSocketConfig.java
+++ b/src/main/java/com/thunder11/scuad/common/config/WebSocketConfig.java
@@ -2,6 +2,7 @@ package com.thunder11.scuad.common.config;
 
 import com.thunder11.scuad.chat.websocket.WebSocketAuthInterceptor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -17,6 +18,12 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+
+    // SecurityConfig의 CORS 설정(frontendUrl만 허용)과 일치시키기 위해 동일한 프로퍼티 주입
+    // 기존 setAllowedOriginPatterns("*")는 운영 환경에서 모든 오리진의 WebSocket 연결을 허용하는
+    // 보안 취약점이 있어 수정
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
     // 메시지 브로커 설정
     // enableSimpleBroker("/topic"): /topic/chat-rooms/{id} 를 구독한 클라이언트들에게 메시지 브로드캐스트
     // setApplicationDestinationPrefixes("/app"): 클라이언트가 서버로 메시지 보낼 때 사용하는 prefix
@@ -35,7 +42,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
                 .addInterceptors(webSocketAuthInterceptor)  // 핸드셰이크 시 JWT 검증
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns(frontendUrl)      // SecurityConfig CORS와 동일하게 제한
                 .withSockJS();
     }
 }

--- a/src/main/java/com/thunder11/scuad/common/config/WebSocketConfig.java
+++ b/src/main/java/com/thunder11/scuad/common/config/WebSocketConfig.java
@@ -1,5 +1,7 @@
 package com.thunder11.scuad.common.config;
 
+import com.thunder11.scuad.chat.websocket.WebSocketAuthInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -11,8 +13,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 // 폴링(2초마다 GET 반복) → WebSocket(서버가 변경 시에만 push) 전환을 위해 추가
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
     // 메시지 브로커 설정
     // enableSimpleBroker("/topic"): /topic/chat-rooms/{id} 를 구독한 클라이언트들에게 메시지 브로드캐스트
     // setApplicationDestinationPrefixes("/app"): 클라이언트가 서버로 메시지 보낼 때 사용하는 prefix
@@ -30,6 +34,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
+                .addInterceptors(webSocketAuthInterceptor)  // 핸드셰이크 시 JWT 검증
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }


### PR DESCRIPTION
# [perf] 채팅 메시지 수신 방식 폴링 → WebSocket 전환

## 1. 문제 상황

채팅 메시지 수신을 위해 클라이언트가 2초마다 `GET /chat-rooms/{id}/messages?since=` API를 반복 호출하는 폴링 구조를 사용하고 있었습니다.

VU 100명 기준 부하 테스트(k6) 결과:

- 30초 동안 총 1,501건 요청 발생
- 새 메시지가 없는 상태에서도 전량 DB까지 도달
- jvm_threads_live: 40 → 123 (스레드 83개 추가 점유)
- hikaricp_acquire_count: 2초마다 +100 증가 (VU 수와 정확히 일치)
```
[폴링 베이스라인 — VU 100명, 30초]
  총 요청 수         : 1,501건 (전량 불필요한 요청)
  RPS                : 49.47 req/s
  p95 응답 시간      : 59.20ms
  jvm_threads_live   : 123 (baseline 40 대비 +83)
  DB acquire_count   : 2초마다 +100 증가
```
VU 10명 → 100명(10배 증가) 시 자원 소모 비교:

| 지표 | VU 10명 | VU 100명 | 변화 |
|---|---|---|---|
| p95 응답 시간 | 27.18ms | 59.20ms | 약 2.2배 증가 |
| jvm_threads_live | 40 | 123 | +83개 |
| DB acquire_count (2초당) | +10 | +100 | 유저 수에 정비례 |
| 총 요청 수 (30초) | 151건 | 1,501건 | 10배 증가 |

유저 수 증가에 따라 불필요한 DB 조회와 스레드 점유가 선형으로 증가하는 구조입니다.

폴링 구조의 근본적인 문제는 **새 메시지 유무와 관계없이 주기적으로 서버·DB 자원을 소모**한다는 점입니다.
유저 수가 늘어날수록 불필요한 요청이 선형으로 증가합니다.

---

## 2. 원인 분석

기존 폴링 구조의 흐름은 아래와 같습니다.
```
클라이언트 → GET /messages?since=xxx (2초마다 반복)
               ↓
           ChatMessageService.getMessages()
               ↓ (새 메시지 없어도 동일)
           chatMessageRepository.findNewMessagesSince()  ← DB 매번 조회
               ↓
           응답 반환 (빈 배열)
```

폴링 주기(2초)와 VU 수의 곱만큼 매 순간 스레드·DB 커넥션이 점유됩니다.
VU 100명 기준 초당 50회 요청이 전부 DB까지 전달되며, 이 중 새 메시지가 있는 요청은 0건이었습니다.

---

## 3. 해결 방법

**WebSocket + STOMP In-Memory 브로커** 방식을 선택했습니다.

### 후보 비교

| 방법 | 적합 여부 | 이유 |
|---|---|---|
| **WebSocket + STOMP (In-Memory)** | ✅ | 외부 인프라 없이 Spring Boot 내장, 변경 범위 최소 |
| WebSocket + Redis Pub/Sub | 🔺 | 다중 서버 확장 시 필요하나 현재 단일 서버 구조에서 과도 |
| SSE (Server-Sent Events) | 🔺 | 서버→클라이언트 단방향만 가능, 메시지 전송 흐름 분리 필요 |
| Long Polling | ❌ | 폴링 대비 개선 효과 미미 |

### 채택 이유 3가지

1. **외부 서버 불필요**: Redis, RabbitMQ 없이 `spring-boot-starter-websocket` 의존성 하나로 In-Memory 브로커가 동작합니다. 클라우드 팀에 인프라 변경 요청 없이 배포 가능합니다. (ALB idle timeout 설정 제외)
2. **변경 범위 최소화**: 기존 REST API(`GET /messages` 히스토리 조회, `POST /messages` 전송)는 그대로 유지하고, 신규 메시지 수신 경로만 WebSocket으로 전환합니다. 파일 전송도 REST 유지(multipart는 WebSocket 처리 불가).
3. **불필요한 요청 구조적 제거**: 클라이언트가 `/topic/chat-rooms/{id}`를 구독하면 새 메시지가 있을 때만 서버가 push합니다. 폴링처럼 주기적으로 스레드·DB를 점유하지 않습니다.

### 트레이드오프

현재 단일 서버 구조에서는 In-Memory 브로커로 충분합니다.
다중 서버(Scale-out) 환경이 되면 서버 간 메시지 공유가 안 되므로 Redis Pub/Sub으로 업그레이드가 필요합니다.

---

## 4. 동작 흐름

### 변경 전 (폴링)
```
클라이언트 A  →  GET /messages?since=xxx  (2초마다 반복)  →  서버  →  DB
클라이언트 B  →  GET /messages?since=xxx  (2초마다 반복)  →  서버  →  DB
클라이언트 C  →  GET /messages?since=xxx  (2초마다 반복)  →  서버  →  DB
```

### 변경 후 (WebSocket)
```
[최초 1회]
클라이언트 A  →  CONNECT ws://서버/ws?token=xxx  →  핸드셰이크 (JWT 검증)
클라이언트 A  →  SUBSCRIBE /topic/chat-rooms/{id}

[메시지 전송 시에만]
클라이언트 A  →  POST /api/v1/chat-rooms/{id}/messages
                  ↓
              ChatMessageService.sendMessage()  →  DB 저장
                  ↓
              messagingTemplate.convertAndSend("/topic/chat-rooms/{id}", result)
                  ↓
클라이언트 A, B, C  ←  브로드캐스트 (새 메시지 즉시 수신)
```

---

## 5. 변경 범위

### `build.gradle`

WebSocket + STOMP 의존성 추가
```gradle
implementation 'org.springframework.boot:spring-boot-starter-websocket'
```

### `WebSocketConfig.java` (신규)

STOMP 엔드포인트, In-Memory 브로커, 메시지 prefix 설정
```java
registry.enableSimpleBroker("/topic");           // 구독 경로
registry.setApplicationDestinationPrefixes("/app"); // 전송 prefix
registry.addEndpoint("/ws")                      // 연결 URL
        .addInterceptors(webSocketAuthInterceptor)
        .setAllowedOriginPatterns("*")
        .withSockJS();
```

### `WebSocketAuthInterceptor.java` (신규)

핸드셰이크 시점에 쿼리 파라미터 `token`으로 JWT 검증 후 `userId`를 WebSocket 세션에 저장
```java
// ws://서버/ws?token=eyJhbGci... 형태로 연결
jwtProvider.validateToken(token);
Long userId = jwtProvider.getUserIdFromToken(token);
attributes.put("userId", userId);  // 이후 메시지 처리 시 세션에서 꺼내 사용
```

### `SecurityConfig.java`

WebSocket 핸드셰이크 경로 허용 추가
```java
.requestMatchers("/ws/**").permitAll()
// SockJS가 /ws/info, /ws/{serverId}/{sessionId}/websocket 등 하위 경로 사용
// 인증은 SecurityConfig가 아닌 WebSocketAuthInterceptor에서 처리
```

### `ChatMessageService.java`

메시지 저장 후 브로드캐스트 추가, `since` 기반 폴링 분기 제거
```java
// 메시지 저장 후 브로드캐스트 추가
messagingTemplate.convertAndSend("/topic/chat-rooms/" + chatRoomId, result);

// getMessages(): since 파라미터 및 폴링 분기 제거 → 커서 페이징 전용
```

### `ChatRoomController.java`

`GET /messages` 에서 `since` 파라미터 제거
```java
// 변경 전
@RequestParam(required = false) Long since

// 변경 후 — 제거
// 신규 메시지 수신은 WebSocket 구독으로 처리
```

### `ChatMessageRepository.java`

폴링 전용 메서드 `findNewMessagesSince()` 삭제 (더 이상 호출하는 곳 없음)

---

## 6. 클라우드 팀 공유 사항

WebSocket은 외부 서비스가 아니라 Spring Boot 내장으로 동작합니다.
추가 인프라 없이 배포 가능하며, **ALB idle timeout 설정 변경만 요청드립니다.**

| 항목 | 요청 내용 |
|---|---|
| ALB idle timeout | 기본값 60초 → **3600초**로 변경 |
| 변경 이유 | WebSocket은 연결을 유지하는데, 60초 동안 메시지가 없으면 ALB가 연결을 강제 종료함 |

---

## 7. 클라이언트 연동 가이드
```
1. WebSocket 연결
   ws://서버주소/ws?token={JWT_ACCESS_TOKEN}

2. 채팅방 구독
   SUBSCRIBE /topic/chat-rooms/{chatRoomId}

3. 메시지 전송 (기존 REST 유지)
   POST /api/v1/chat-rooms/{chatRoomId}/messages

4. 메시지 수신
   SUBSCRIBE 구독 중인 클라이언트에게 자동 브로드캐스트

5. 과거 메시지 로드 (기존 REST 유지, since 파라미터만 제거)
   GET /api/v1/chat-rooms/{chatRoomId}/messages?cursor={cursor}&size={size}
```