### PR TITLE
Feature/mypage getuser

### DIFF
--- a/src/main/java/com/thunder11/scuad/user/dto/UserResponse.java
+++ b/src/main/java/com/thunder11/scuad/user/dto/UserResponse.java
@@ -1,8 +1,6 @@
 package com.thunder11.scuad.user.dto;
 
-import com.thunder11.scuad.auth.domain.Role;
 import com.thunder11.scuad.auth.domain.User;
-import com.thunder11.scuad.auth.domain.UserStatus;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -15,19 +13,21 @@ public class UserResponse {
 
     private Long userId;
     private String nickname;
-    private String email;  // OAuth 계정의 이메일 (null 가능)
-    private Long profileImageFileId;
+    private String email;               // OAuth 계정 이메일 (null 허용, read-only)
+    private Long profileImageFileId;    // 파일 식별자 (null 허용)
+    // presigned URL 포함: 클라이언트가 추가 API 호출 없이 이미지를 즉시 렌더링하기 위함
+    private String profileImageUrl;     // S3 presigned URL (null 허용, 이미지 없으면 null)
     private String role;
     private String status;
 
-
-    // User 엔티티와 이메일로 UserResponse 생성
-    public static UserResponse of(User user, String email) {
+    // User 엔티티, 이메일, presigned URL로 UserResponse 생성
+    public static UserResponse of(User user, String email, String profileImageUrl) {
         return UserResponse.builder()
                 .userId(user.getUserId())
                 .nickname(user.getNickname())
                 .email(email)
                 .profileImageFileId(user.getProfileImageFileId())
+                .profileImageUrl(profileImageUrl)
                 .role(user.getRole().name())
                 .status(user.getStatus().name())
                 .build();

--- a/src/main/java/com/thunder11/scuad/user/service/UserService.java
+++ b/src/main/java/com/thunder11/scuad/user/service/UserService.java
@@ -1,13 +1,17 @@
 package com.thunder11.scuad.user.service;
 
+import java.time.Duration;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.thunder11.scuad.auth.domain.User;
+import com.thunder11.scuad.auth.domain.UserStatus;
 import com.thunder11.scuad.auth.repository.UserOAuthAccountRepository;
 import com.thunder11.scuad.auth.repository.UserRepository;
 import com.thunder11.scuad.common.exception.ApiException;
 import com.thunder11.scuad.common.exception.ErrorCode;
+import com.thunder11.scuad.file.service.S3FileManagementService;
 import com.thunder11.scuad.user.dto.UserResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -21,18 +25,47 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserOAuthAccountRepository userOAuthAccountRepository;
+    private final S3FileManagementService s3FileManagementService;
+
+    // presigned URL 유효 시간: 클라이언트 세션 내 이미지 표시에 충분한 시간으로 설정
+    private static final Duration PROFILE_IMAGE_URL_EXPIRATION = Duration.ofMinutes(10);
 
     // 현재 로그인한 사용자 정보 조회
+    // WITHDRAWN 상태 사용자는 403 반환 (탈퇴 완료 후 잔여 토큰 재사용 차단)
     public UserResponse getCurrentUser(Long userId) {
-        // 1. users 테이블에서 사용자 조회
+        // 1. 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
 
-        // 2. user_oauth_accounts 테이블에서 이메일 조회 (KAKAO 기준)
-        String email = userOAuthAccountRepository.findEmailByUserId(userId)
-                .orElse(null);  // 이메일이 없을 수 있음 (카카오 동의 안 함)
+        // 2. 탈퇴 사용자 접근 차단
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            throw new ApiException(ErrorCode.FORBIDDEN);
+        }
 
-        // 3. UserResponse 생성 및 반환
-        return UserResponse.of(user, email);
+        // 3. user_oauth_accounts에서 이메일 조회 (KAKAO 기준, null 허용)
+        String email = userOAuthAccountRepository.findEmailByUserId(userId)
+                .orElse(null);
+
+        // 4. 프로필 이미지 presigned URL 생성 (이미지가 없으면 null 반환)
+        String profileImageUrl = resolveProfileImageUrl(user.getProfileImageFileId());
+
+        return UserResponse.of(user, email, profileImageUrl);
+    }
+
+    // 프로필 이미지 presigned URL 생성 헬퍼
+    // fileId가 null이거나 S3 오류 발생 시 null 반환
+    // 이미지 오류가 사용자 정보 전체 조회를 실패시키지 않도록 예외를 흡수
+    private String resolveProfileImageUrl(Long profileImageFileId) {
+        if (profileImageFileId == null) {
+            return null;
+        }
+        try {
+            return s3FileManagementService.generatePresignedUrl(
+                    profileImageFileId,
+                    PROFILE_IMAGE_URL_EXPIRATION
+            );
+        } catch (ApiException e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
# Feat : GET /api/v1/users/me 회원정보 조회 개선

---

## 작업 내용

### **커밋 1: UserResponse에 profileImageUrl 필드 추가**

- 기존 `profileImageFileId`(Long)에 더해 `profileImageUrl`(String) 필드 추가
- `UserResponse.of()` 팩토리 메서드 시그니처 변경 (email, profileImageUrl 인자 추가)

### **커밋 2: 회원정보 조회 개선 - 탈퇴 사용자 차단 및 프로필 이미지 URL 포함**

- `UserStatus.WITHDRAWN` 사용자 접근 시 `403 FORBIDDEN` 반환
- `S3FileManagementService.generatePresignedUrl()` 호출로 presigned URL 조합
- 이미지 없거나 S3 오류 발생 시 `profileImageUrl = null` 반환 (조회 전체 실패 방지)
- `PROFILE_IMAGE_URL_EXPIRATION` 상수 10분으로 정의

---

## 설계 의도

### **왜 profileImageUrl을 응답에 포함하는가?**

채팅방 멤버 목록, 공고 화면 등 프로필 이미지가 여러 화면에 노출되는 서비스 특성상, 클라이언트가 `fileId`만 받으면 이미지를 표시할 때마다 `GET /api/v1/files/{id}/download-url`을 추가 호출해야 합니다.

`GET /me` 응답 한 번으로 URL까지 제공하면 불필요한 네트워크 왕복을 줄일 수 있습니다. presigned URL 만료 시에는 클라이언트가 `GET /me`를 재호출하여 갱신합니다.

### **왜 presigned URL 오류를 흡수(null 반환)하는가?**

S3 오류나 파일 삭제로 인해 presigned URL 생성에 실패하더라도 닉네임, 이메일 등 나머지 정보는 정상적으로 제공되어야 합니다. 이미지 오류가 사용자 정보 전체 조회를 실패시키는 것은 과도한 영향 범위입니다.

### **탈퇴 사용자 403 반환 의도**

탈퇴 완료 후에도 Access Token 만료 전까지는 API 호출이 가능합니다. 클라이언트는 `403`을 수신하면 강제 로그아웃(토큰 삭제 + 로그인 화면 이동) 처리를 수행해야 합니다.

---

## API 명세

### GET /api/v1/users/me

**설명**: 현재 로그인한 사용자 정보를 조회합니다.

**권한**: 인증 필요 (Access Token)

**성공 응답 (200 OK)**:
```json
{
  "status": 200,
  "code": "USER_001",
  "message": "사용자 정보를 성공적으로 조회했습니다.",
  "data": {
    "userId": 1,
    "nickname": "김철수",
    "email": "user@kakao.com",
    "profileImageFileId": 42,
    "profileImageUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/profiles/...",
    "role": "USER",
    "status": "ACTIVE"
  }
}
```

**실패 응답**:

`403 FORBIDDEN` — 탈퇴한 사용자:
```json
{
  "status": 403,
  "code": "FORBIDDEN",
  "message": "권한이 없습니다.",
  "data": null
}
```

`404 NOT_FOUND` — 존재하지 않는 사용자:
```json
{
  "status": 404,
  "code": "USER_NOT_FOUND",
  "message": "사용자를 찾을 수 없습니다.",
  "data": null
}
```

---

## 비즈니스 플로우
```
1. 클라이언트 요청
   ↓ GET /api/v1/users/me
   ↓ Authorization: Bearer {token}

2. JwtAuthenticationFilter
   ↓ 토큰 검증 → UserPrincipal 생성

3. UserController.getCurrentUser()
   ↓ @AuthenticationPrincipal로 userId 추출

4. UserService.getCurrentUser(userId)
   ↓ UserRepository.findById() → USER_NOT_FOUND 또는 FORBIDDEN(탈퇴)
   ↓ UserOAuthAccountRepository.findEmailByUserId() → email (null 허용)
   ↓ S3FileManagementService.generatePresignedUrl() → profileImageUrl (null 허용)
   ↓ UserResponse.of() 조합

5. 응답 반환
   ↓ ApiResponse<UserResponse>
```