### PR TITLE
Feature/auth user fix

### DIFF
--- a/src/main/java/com/thunder11/scuad/auth/domain/User.java
+++ b/src/main/java/com/thunder11/scuad/auth/domain/User.java
@@ -56,6 +56,13 @@ public class User extends BaseTimeEntity {
         this.nickname = nickname;
     }
 
+    // 프로필 이미지 파일 ID 변경
+    // null 허용: 이미지 제거 시 null 전달
+    // 파일 존재 여부 검증은 서비스 레이어에서 수행
+    public void updateProfileImageFileId(Long profileImageFileId) {
+        this.profileImageFileId = profileImageFileId;
+    }
+
     // 회원 탈퇴 처리 (상태 변경 및 탈퇴 시각 기록)
     public void withdraw() {
         this.status = UserStatus.WITHDRAWN;

--- a/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
+++ b/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
@@ -51,6 +51,8 @@ public enum ErrorCode {
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE_NOT_FOUND", "파일을 찾을 수 없습니다."),
     FILE_DOWNLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_DOWNLOAD_ERROR", "파일 다운로드 URL 생성에 실패했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE", "since와 cursor를 동시에 사용할 수 없습니다"),
+    NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "USER_002", "이미 사용 중인 닉네임입니다."),
+    USER_ALREADY_WITHDRAWN(HttpStatus.FORBIDDEN, "USER_003", "이미 탈퇴한 사용자입니다."),
     COMPARISON_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "COMPARISON_SELF_NOT_ALLOWED", "자기 자신과는 비교할 수 없습니다."),
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DOCUMENT_NOT_FOUND", "제출된 문서가 없습니다.");
 

--- a/src/main/java/com/thunder11/scuad/user/controller/UserController.java
+++ b/src/main/java/com/thunder11/scuad/user/controller/UserController.java
@@ -1,10 +1,10 @@
 package com.thunder11.scuad.user.controller;
 
+import com.thunder11.scuad.user.dto.request.UserUpdateRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.thunder11.scuad.auth.security.UserPrincipal;
 import com.thunder11.scuad.common.response.ApiResponse;
@@ -37,6 +37,27 @@ public class UserController {
                         200,
                         "USER_001",
                         "사용자 정보를 성공적으로 조회했습니다.",
+                        userResponse
+                )
+        );
+    }
+
+    // 회원정보 수정
+    // PATCH /api/v1/users/me
+    // 변경하지 않을 필드는 요청 body에 포함하지 않습니다
+    // email은 수정 불가(read-only)이며 요청에 포함해도 무시됩니다
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> updateCurrentUser(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody UserUpdateRequest request
+    ) {
+        UserResponse userResponse = userService.updateUser(userPrincipal.getUserId(), request);
+
+        return ResponseEntity.ok(
+                ApiResponse.of(
+                        200,
+                        "USER_002",
+                        "사용자 정보를 성공적으로 수정했습니다.",
                         userResponse
                 )
         );

--- a/src/main/java/com/thunder11/scuad/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/thunder11/scuad/user/dto/request/UserUpdateRequest.java
@@ -1,0 +1,33 @@
+package com.thunder11.scuad.user.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 회원정보 수정 요청 DTO
+// PATCH /api/v1/users/me
+// 모든 필드는 선택적(Optional): 요청에 포함된 필드만 수정하는 PATCH 시맨틱
+// email은 OAuth 제공 정보이므로 수정 대상에서 제외
+@Getter
+@NoArgsConstructor
+public class UserUpdateRequest {
+
+    // 변경할 닉네임 (선택)
+    // users.nickname VARCHAR(30) 기준으로 길이 제한
+    @Size(min = 1, max = 30, message = "닉네임은 1자 이상 30자 이하여야 합니다.")
+    private String nickname;
+
+    // 변경할 프로필 이미지 파일 ID (선택)
+    // file_objects 존재 여부는 서비스 레이어에서 검증
+    private Long profileImageFileId;
+
+    // 닉네임 변경 요청 여부: null이면 변경 요청 없음
+    public boolean hasNicknameUpdate() {
+        return nickname != null;
+    }
+
+    // 프로필 이미지 변경 요청 여부: null이면 변경 요청 없음
+    public boolean hasProfileImageUpdate() {
+        return profileImageFileId != null;
+    }
+}

--- a/src/main/java/com/thunder11/scuad/user/service/UserService.java
+++ b/src/main/java/com/thunder11/scuad/user/service/UserService.java
@@ -13,6 +13,9 @@ import com.thunder11.scuad.common.exception.ApiException;
 import com.thunder11.scuad.common.exception.ErrorCode;
 import com.thunder11.scuad.file.service.S3FileManagementService;
 import com.thunder11.scuad.user.dto.UserResponse;
+import org.springframework.dao.DataIntegrityViolationException;
+import com.thunder11.scuad.file.repository.FileObjectRepository;
+import com.thunder11.scuad.user.dto.request.UserUpdateRequest;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,7 +29,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserOAuthAccountRepository userOAuthAccountRepository;
     private final S3FileManagementService s3FileManagementService;
-
+    private final FileObjectRepository fileObjectRepository;
     // presigned URL 유효 시간: 클라이언트 세션 내 이미지 표시에 충분한 시간으로 설정
     private static final Duration PROFILE_IMAGE_URL_EXPIRATION = Duration.ofMinutes(10);
 
@@ -49,6 +52,54 @@ public class UserService {
         // 4. 프로필 이미지 presigned URL 생성 (이미지가 없으면 null 반환)
         String profileImageUrl = resolveProfileImageUrl(user.getProfileImageFileId());
 
+        return UserResponse.of(user, email, profileImageUrl);
+    }
+
+    // 회원정보 수정
+    // 닉네임 중복 시 DataIntegrityViolationException을 NICKNAME_DUPLICATE로 변환
+    // DB 예외가 컨트롤러 계층에 노출되면 클라이언트가 원인을 알 수 없으므로 도메인 예외로 변환
+    @Transactional
+    public UserResponse updateUser(Long userId, UserUpdateRequest request) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. 탈퇴 사용자 수정 차단
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            throw new ApiException(ErrorCode.USER_ALREADY_WITHDRAWN);
+        }
+
+        // 3. 닉네임 수정 (요청 시)
+        if (request.hasNicknameUpdate()) {
+            // 공백만으로 구성된 닉네임 차단 ("   " 등 실질적 빈 값)
+            if (request.getNickname().isBlank()) {
+                throw new ApiException(ErrorCode.VALIDATION_FAILED);
+            }
+            user.updateNickname(request.getNickname());
+        }
+
+        // 4. 프로필 이미지 수정 (요청 시)
+        // 존재하지 않는 파일 ID 저장 시 FK 위반 및 데이터 불일치 방지를 위해 사전 검증
+        if (request.hasProfileImageUpdate()) {
+            boolean fileExists = fileObjectRepository.existsByIdAndNotDeleted(
+                    request.getProfileImageFileId()
+            );
+            if (!fileExists) {
+                throw new ApiException(ErrorCode.FILE_NOT_FOUND);
+            }
+            user.updateProfileImageFileId(request.getProfileImageFileId());
+        }
+
+        // 5. 저장 (닉네임 중복 시 DataIntegrityViolationException → NICKNAME_DUPLICATE 변환)
+        try {
+            userRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException e) {
+            throw new ApiException(ErrorCode.NICKNAME_DUPLICATE);
+        }
+
+        // 6. 변경된 사용자 정보 반환
+        String email = userOAuthAccountRepository.findEmailByUserId(userId).orElse(null);
+        String profileImageUrl = resolveProfileImageUrl(user.getProfileImageFileId());
         return UserResponse.of(user, email, profileImageUrl);
     }
 


### PR DESCRIPTION
# feat : PATCH /api/v1/users/me 회원정보 수정 API 구현

---

## 작업 내용

### **커밋 1: 사용자 도메인 에러 코드 추가**

- `ErrorCode`에 `NICKNAME_DUPLICATE` (409), `USER_ALREADY_WITHDRAWN` (403) 추가

### **커밋 2: User 엔티티에 updateProfileImageFileId() 메서드 추가**

- 프로필 이미지 파일 ID 변경용 도메인 메서드 추가
- null 허용 (이미지 제거 시 null 전달 가능)

### **커밋 3: 회원정보 수정 요청 DTO 추가**

- `UserUpdateRequest` 클래스 생성 (`nickname`, `profileImageFileId` 선택적 필드)
- `hasNicknameUpdate()`, `hasProfileImageUpdate()` 판별 메서드 포함
- `@Size` 검증으로 닉네임 길이 제한 (1~30자)

### **커밋 4: UserService에 회원정보 수정 로직 추가**

- `updateUser()` 메서드 구현
- 탈퇴 사용자 수정 차단 (403)
- 공백 닉네임 차단
- `profileImageFileId` 변경 시 `file_objects` 존재 여부 사전 검증
- `DataIntegrityViolationException` → `NICKNAME_DUPLICATE` 도메인 예외 변환

### **커밋 5: 회원정보 수정 API 엔드포인트 추가**

- `PATCH /api/v1/users/me` 엔드포인트 추가
- `@Valid`로 요청 검증 수행

---

## 설계 의도

### **왜 PATCH를 사용하는가?**

PUT은 전체 리소스 교체 시맨틱입니다. 닉네임과 이미지 중 하나만 바꾸려면 나머지도 항상 전송해야 하는 불편함이 생깁니다. PATCH는 변경할 필드만 포함하면 되어 클라이언트 구현이 단순해집니다.

### **DataIntegrityViolationException 변환 의도**

DB 레벨 UNIQUE 제약 위반 예외를 그대로 상위로 전달하면 클라이언트는 500이나 의미 없는 에러를 받게 됩니다. `saveAndFlush()`로 즉시 flush하여 같은 트랜잭션 내에서 예외를 포착하고, `NICKNAME_DUPLICATE`(409)로 변환하여 명확한 원인을 전달합니다.

### **프로필 이미지 사전 검증 의도**

`profileImageFileId`에 존재하지 않는 파일 ID를 저장하면 FK 위반 또는 이후 URL 생성 시 에러가 발생합니다. 서비스 레이어에서 `existsByIdAndNotDeleted()`로 선제 검증하여 데이터 무결성을 보장합니다.

---

## API 명세

### PATCH /api/v1/users/me

**설명**: 현재 로그인한 사용자의 정보를 수정합니다. 변경할 필드만 포함합니다.

**권한**: 인증 필요 (Access Token)

**요청 Body** (모든 필드 선택적):

| 필드 | 타입 | 설명 |
|------|------|------|
| nickname | String | 변경할 닉네임 (1~30자) |
| profileImageFileId | Long | 변경할 프로필 이미지 파일 ID |

**요청 예시**:
```json
{
  "nickname": "새닉네임",
  "profileImageFileId": 42
}
```

**성공 응답 (200 OK)**:
```json
{
  "status": 200,
  "code": "USER_002",
  "message": "사용자 정보를 성공적으로 수정했습니다.",
  "data": {
    "userId": 1,
    "nickname": "새닉네임",
    "email": "user@kakao.com",
    "profileImageFileId": 42,
    "profileImageUrl": "https://...",
    "role": "USER",
    "status": "ACTIVE"
  }
}
```

**실패 응답**:

`409 CONFLICT` — 닉네임 중복:
```json
{ "status": 409, "code": "USER_002", "message": "이미 사용 중인 닉네임입니다.", "data": null }
```

`404 NOT_FOUND` — 파일 미존재:
```json
{ "status": 404, "code": "FILE_NOT_FOUND", "message": "파일을 찾을 수 없습니다.", "data": null }
```

`400 BAD_REQUEST` — 검증 실패 (빈 닉네임, 길이 초과):
```json
{ "status": 400, "code": "VALIDATION_FAILED", "message": "요청 값이 올바르지 않습니다.", "data": null }
```

---

## 비즈니스 플로우
```
1. 클라이언트 요청
   ↓ PATCH /api/v1/users/me
   ↓ Body: { "nickname": "새닉네임" }

2. JwtAuthenticationFilter → UserPrincipal 생성

3. UserController.updateCurrentUser()
   ↓ @Valid 검증 (길이 등)

4. UserService.updateUser(userId, request)
   ↓ UserRepository.findById() → 사용자 조회
   ↓ WITHDRAWN 체크 → 403
   ↓ hasNicknameUpdate() → updateNickname()
   ↓ hasProfileImageUpdate() → existsByIdAndNotDeleted() → updateProfileImageFileId()
   ↓ saveAndFlush() → DataIntegrityViolationException → NICKNAME_DUPLICATE(409)
   ↓ UserResponse.of() 조합 후 반환
```