### PR TITLE
Feature/delete user

### DIFF
--- a/src/main/java/com/thunder11/scuad/auth/controller/AuthController.java
+++ b/src/main/java/com/thunder11/scuad/auth/controller/AuthController.java
@@ -15,6 +15,7 @@ import com.thunder11.scuad.auth.dto.LoginResponse;
 import com.thunder11.scuad.auth.service.AuthService;
 import com.thunder11.scuad.auth.dto.RefreshTokenRequest;
 import com.thunder11.scuad.auth.dto.TokenRefreshResponse;
+import com.thunder11.scuad.common.exception.ApiException;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -60,33 +61,47 @@ public class AuthController {
     ) {
         log.info("카카오 콜백 처리 시작: code={}", code.substring(0, 10) + "...");
 
-        // 인가 코드로 로그인 처리 및 JWT 발급
-        LoginResponse loginResponse = authService.processKakaoCallback(code);
+        try {
+            // 인가 코드로 로그인 처리 및 JWT 발급
+            LoginResponse loginResponse = authService.processKakaoCallback(code);
 
-        // Refresh Token을 HttpOnly 쿠키로 설정
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", loginResponse.getRefreshToken())
-                .httpOnly(true)                    // JavaScript 접근 차단 (XSS 방어)
-                .secure(true)                      // HTTPS에서만 전송 (중간자 공격 방어)
-                .path("/api/v1/auth")              // 토큰 재발급 API에만 쿠키 전송
-                .maxAge(14 * 24 * 60 * 60)         // 14일 (초 단위)
-                .sameSite("Lax")                   // CSRF 기본 방어
-                .domain(cookieDomain)
-                .build();
+            // Refresh Token을 HttpOnly 쿠키로 설정
+            ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", loginResponse.getRefreshToken())
+                    .httpOnly(true)                    // JavaScript 접근 차단 (XSS 방어)
+                    .secure(true)                      // HTTPS에서만 전송 (중간자 공격 방어)
+                    .path("/api/v1/auth")              // 토큰 재발급 API에만 쿠키 전송
+                    .maxAge(14 * 24 * 60 * 60)         // 14일 (초 단위)
+                    .sameSite("Lax")                   // CSRF 기본 방어
+                    .domain(cookieDomain)
+                    .build();
 
-        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
-        log.info("Refresh Token을 HttpOnly 쿠키로 설정 완료");
+            response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+            log.info("Refresh Token을 HttpOnly 쿠키로 설정 완료");
 
-        // 프론트엔드로 리다이렉트 (JWT 토큰 전달)
-        // TODO: 프론트엔드 URL은 환경변수로 관리 필요
-        String frontendUrl = UriComponentsBuilder
-                .fromUriString(frontendUrlBase + "/auth/callback") // 프론트엔드 콜백 URL
-                .queryParam("accessToken", loginResponse.getAccessToken())
-                .queryParam("expiresIn", loginResponse.getExpiresIn())
-                .build()
-                .toUriString();
+            // 프론트엔드로 리다이렉트 (JWT 토큰 전달)
+            String frontendUrl = UriComponentsBuilder
+                    .fromUriString(frontendUrlBase + "/auth/callback")
+                    .queryParam("accessToken", loginResponse.getAccessToken())
+                    .queryParam("expiresIn", loginResponse.getExpiresIn())
+                    .build()
+                    .toUriString();
 
-        log.info("로그인 성공, 프론트엔드로 리다이렉트");
-        return new RedirectView(frontendUrl);
+            log.info("로그인 성공, 프론트엔드로 리다이렉트");
+            return new RedirectView(frontendUrl);
+
+        } catch (ApiException e) {
+            // 탈퇴 사용자 등 도메인 예외 발생 시 에러 파라미터와 함께 프론트로 리다이렉트
+            // 프론트는 error 파라미터를 확인하여 적절한 안내 메시지를 표시
+            log.warn("카카오 콜백 처리 중 도메인 예외 발생: code={}", e.getErrorCode().getCode());
+
+            String errorRedirectUrl = UriComponentsBuilder
+                    .fromUriString(frontendUrlBase + "/auth/callback")
+                    .queryParam("error", e.getErrorCode().getCode())
+                    .build()
+                    .toUriString();
+
+            return new RedirectView(errorRedirectUrl);
+        }
     }
 
     // Access Token 재발급

--- a/src/main/java/com/thunder11/scuad/auth/domain/User.java
+++ b/src/main/java/com/thunder11/scuad/auth/domain/User.java
@@ -63,8 +63,20 @@ public class User extends BaseTimeEntity {
         this.profileImageFileId = profileImageFileId;
     }
 
-    // 회원 탈퇴 처리 (상태 변경 및 탈퇴 시각 기록)
-    public void withdraw() {
+    // 탈퇴 처리: 상태 변경 + deleted_at 설정 + 닉네임 패턴 변경
+    // 닉네임을 deleted_{userId}_{원본닉네임} 패턴으로 변경하여 UNIQUE 제약을 해제
+    // 이렇게 해야 동일 카카오 계정으로 재가입 시 같은 닉네임 사용이 가능
+    // VARCHAR(30) 제한 초과 시 원본 닉네임을 truncate 처리
+    public void applyWithdrawalNicknamePattern() {
+        String prefix = "deleted_" + this.userId + "_";
+        int maxLength = 30;
+        int remainingLength = maxLength - prefix.length();
+
+        String truncatedOriginal = this.nickname.length() > remainingLength
+                ? this.nickname.substring(0, Math.max(remainingLength, 0))
+                : this.nickname;
+
+        this.nickname = prefix + truncatedOriginal;
         this.status = UserStatus.WITHDRAWN;
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
+++ b/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import com.thunder11.scuad.auth.domain.*;
+import com.thunder11.scuad.auth.domain.UserStatus;
 import com.thunder11.scuad.auth.dto.TokenRefreshResponse;
 import com.thunder11.scuad.common.exception.ApiException;
 import com.thunder11.scuad.common.exception.ErrorCode;
@@ -86,6 +87,15 @@ public class AuthService {
                 .orElseGet(() -> registerNewUser(userInfo));
 
         User user = oAuthAccount.getUser();
+
+        // 탈퇴 사용자 로그인 차단
+        // Soft Delete 특성상 user_oauth_accounts 레코드는 남아있어 계정 조회가 되지만
+        // WITHDRAWN 상태 확인 후 JWT 발급 전에 차단해야 재로그인을 막을 수 있음
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            log.warn("탈퇴한 사용자 로그인 시도 차단: userId={}", user.getUserId());
+            throw new ApiException(ErrorCode.WITHDRAWN_USER);
+        }
+
         log.info("사용자 인증 완료: userId={}, nickname={}", user.getUserId(), user.getNickname());
 
         // 4. JWT 토큰 발급

--- a/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
+++ b/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_EXPIRED", "리프레시 토큰이 만료되었습니다. 다시 로그인해주세요."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_NOT_FOUND", "리프레시 토큰을 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    WITHDRAWN_USER(HttpStatus.FORBIDDEN, "WITHDRAWN_USER", "탈퇴한 계정입니다."),
     KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "KAKAO_TOKEN_REQUEST_FAILED", "카카오 토큰 발급에 실패했습니다."),
     KAKAO_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO_API_ERROR", "카카오 API 호출 중 오류가 발생했습니다."),
 

--- a/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
+++ b/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다."),
     AI_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI_SERVICE_ERROR", "AI 서비스 연동 중 오류가 발생했습니다."),
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_UPLOAD_ERROR","파일 업로드 중 오류가 발생했습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "INVALID_FILE_TYPE", "이미지 파일만 업로드할 수 있습니다."),
     ACCEPTED(HttpStatus.ACCEPTED, "ACCEPTED", "요청이 접수되어 처리 중입니다."),
 
     // oauth 도메인 에러

--- a/src/main/java/com/thunder11/scuad/file/controller/FileController.java
+++ b/src/main/java/com/thunder11/scuad/file/controller/FileController.java
@@ -2,16 +2,26 @@ package com.thunder11.scuad.file.controller;
 
 import java.time.Duration;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.thunder11.scuad.auth.security.UserPrincipal;
+import com.thunder11.scuad.common.exception.ApiException;
+import com.thunder11.scuad.common.exception.ErrorCode;
 import com.thunder11.scuad.common.response.ApiResponse;
+import com.thunder11.scuad.file.domain.FileObject;
 import com.thunder11.scuad.file.dto.response.FileDownloadUrlResponse;
+import com.thunder11.scuad.file.dto.response.FileUploadResponse;
 import com.thunder11.scuad.file.service.S3FileManagementService;
 
 // 파일 관련 API 컨트롤러
@@ -22,6 +32,50 @@ import com.thunder11.scuad.file.service.S3FileManagementService;
 public class FileController {
 
     private final S3FileManagementService fileManagementService;
+
+    // 기본 업로드 디렉토리: 경로 미지정 시 사용
+    private static final String DEFAULT_DIRECTORY = "general";
+
+    // 파일 업로드
+    // POST /api/v1/files/upload
+    // 이미지 타입(image/*)만 허용: 프로필 이미지 등 이미지 전용 업로드 용도
+    // directory 파라미터로 S3 경로 분리 가능 (예: profiles, resumes)
+    // 업로드 완료 후 fileId와 미리보기용 presigned URL을 함께 반환
+    @PostMapping("/upload")
+    public ResponseEntity<ApiResponse<FileUploadResponse>> uploadFile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "directory", defaultValue = DEFAULT_DIRECTORY) String directory
+    ) {
+        log.info("POST /api/v1/files/upload: userId={}, directory={}, contentType={}",
+                userPrincipal.getUserId(), directory, file.getContentType());
+
+        // 이미지 타입 검증: null이거나 image/로 시작하지 않으면 거부
+        // S3 업로드 전에 차단하여 불필요한 네트워크 비용 방지
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new ApiException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        // 빈 파일 업로드 차단
+        if (file.isEmpty()) {
+            throw new ApiException(ErrorCode.VALIDATION_FAILED);
+        }
+
+        FileObject fileObject = fileManagementService.uploadFile(file, directory);
+
+        // 업로드 직후 미리보기용 presigned URL 생성 (10분 유효)
+        String downloadUrl = fileManagementService.generatePresignedUrl(
+                fileObject.getId(),
+                Duration.ofMinutes(10)
+        );
+
+        FileUploadResponse response = FileUploadResponse.of(fileObject, downloadUrl);
+
+        return ResponseEntity.ok(
+                ApiResponse.of(200, "FILE_002", "파일이 성공적으로 업로드되었습니다.", response)
+        );
+    }
 
     // 파일 다운로드 URL 생성 (10분 유효)
     @GetMapping("/{fileId}/download-url")

--- a/src/main/java/com/thunder11/scuad/file/dto/response/FileUploadResponse.java
+++ b/src/main/java/com/thunder11/scuad/file/dto/response/FileUploadResponse.java
@@ -1,0 +1,31 @@
+package com.thunder11.scuad.file.dto.response;
+
+import com.thunder11.scuad.file.domain.FileObject;
+import lombok.Builder;
+import lombok.Getter;
+
+// 파일 업로드 응답 DTO
+// POST /api/v1/files/upload 응답용
+// fileId: 이후 PATCH /api/v1/users/me 등에서 참조할 파일 식별자
+// downloadUrl: 업로드 직후 클라이언트가 이미지를 즉시 미리보기할 수 있도록 presigned URL 포함
+@Getter
+@Builder
+public class FileUploadResponse {
+
+    private Long fileId;
+    private String originalName;
+    private String contentType;
+    private Long sizeBytes;
+    private String downloadUrl;     // 업로드 직후 미리보기용 presigned URL (10분 유효)
+
+    // FileObject 엔티티와 presigned URL로 응답 DTO 생성
+    public static FileUploadResponse of(FileObject fileObject, String downloadUrl) {
+        return FileUploadResponse.builder()
+                .fileId(fileObject.getId())
+                .originalName(fileObject.getOriginalName())
+                .contentType(fileObject.getContentType())
+                .sizeBytes(fileObject.getSizeBytes())
+                .downloadUrl(downloadUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/thunder11/scuad/user/controller/UserController.java
+++ b/src/main/java/com/thunder11/scuad/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.thunder11.scuad.user.controller;
 
+import com.thunder11.scuad.user.dto.request.UserWithdrawalRequest;
 import com.thunder11.scuad.user.dto.request.UserUpdateRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -59,6 +60,25 @@ public class UserController {
                         "USER_002",
                         "사용자 정보를 성공적으로 수정했습니다.",
                         userResponse
+                )
+        );
+    }
+
+    // 회원 탈퇴
+    // DELETE /api/v1/users/me
+    // 탈퇴 완료 후 클라이언트는 로컬 토큰을 삭제하고 로그인 화면으로 이동해야 합니다
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> withdrawCurrentUser(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody UserWithdrawalRequest request
+    ) {
+        userService.withdrawUser(userPrincipal.getUserId(), request);
+
+        return ResponseEntity.ok(
+                ApiResponse.of(
+                        200,
+                        "USER_003",
+                        "회원 탈퇴가 완료되었습니다."
                 )
         );
     }

--- a/src/main/java/com/thunder11/scuad/user/domain/UserWithdrawal.java
+++ b/src/main/java/com/thunder11/scuad/user/domain/UserWithdrawal.java
@@ -1,0 +1,60 @@
+package com.thunder11.scuad.user.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.thunder11.scuad.auth.domain.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 회원 탈퇴 사유 기록 엔티티
+// user_withdrawals 테이블 매핑
+// user_id UNIQUE 제약으로 유저당 1회 탈퇴만 기록 (DB 레벨 보장)
+// 서비스 개선 및 탈퇴 통계 분석 목적으로 사용
+@Entity
+@Table(name = "user_withdrawals")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserWithdrawal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "withdrawal_id")
+    private Long withdrawalId;
+
+    // 탈퇴한 사용자 (UNIQUE 제약으로 동일 사용자 중복 기록 방지)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    // 탈퇴 사유 (필수, 서비스 개선 목적)
+    @Column(name = "reason", nullable = false, columnDefinition = "TEXT")
+    private String reason;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UserWithdrawal(User user, String reason) {
+        this.user = user;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/thunder11/scuad/user/dto/request/UserWithdrawalRequest.java
+++ b/src/main/java/com/thunder11/scuad/user/dto/request/UserWithdrawalRequest.java
@@ -1,0 +1,20 @@
+package com.thunder11.scuad.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 회원 탈퇴 요청 DTO
+// DELETE /api/v1/users/me
+// reason 필수: 빈 값 수집을 방지하고 서비스 개선에 의미 있는 데이터만 저장
+@Getter
+@NoArgsConstructor
+public class UserWithdrawalRequest {
+
+    // 탈퇴 사유 (필수)
+    // user_withdrawals.reason TEXT 기준 최대 1000자 제한
+    @NotBlank(message = "탈퇴 사유는 필수입니다.")
+    @Size(max = 1000, message = "탈퇴 사유는 1000자 이하여야 합니다.")
+    private String reason;
+}

--- a/src/main/java/com/thunder11/scuad/user/repository/UserWithdrawalRepository.java
+++ b/src/main/java/com/thunder11/scuad/user/repository/UserWithdrawalRepository.java
@@ -1,0 +1,13 @@
+package com.thunder11.scuad.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.thunder11.scuad.user.domain.UserWithdrawal;
+
+// 회원 탈퇴 사유 리포지토리
+// user_withdrawals 테이블 접근
+public interface UserWithdrawalRepository extends JpaRepository<UserWithdrawal, Long> {
+
+    // 사용자 ID로 탈퇴 기록 존재 여부 확인 (중복 탈퇴 방지용)
+    boolean existsByUser_UserId(Long userId);
+}

--- a/src/main/java/com/thunder11/scuad/user/service/UserService.java
+++ b/src/main/java/com/thunder11/scuad/user/service/UserService.java
@@ -16,6 +16,10 @@ import com.thunder11.scuad.user.dto.UserResponse;
 import org.springframework.dao.DataIntegrityViolationException;
 import com.thunder11.scuad.file.repository.FileObjectRepository;
 import com.thunder11.scuad.user.dto.request.UserUpdateRequest;
+import com.thunder11.scuad.auth.repository.AuthRefreshTokenRepository;
+import com.thunder11.scuad.user.domain.UserWithdrawal;
+import com.thunder11.scuad.user.dto.request.UserWithdrawalRequest;
+import com.thunder11.scuad.user.repository.UserWithdrawalRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +34,8 @@ public class UserService {
     private final UserOAuthAccountRepository userOAuthAccountRepository;
     private final S3FileManagementService s3FileManagementService;
     private final FileObjectRepository fileObjectRepository;
+    private final UserWithdrawalRepository userWithdrawalRepository;
+    private final AuthRefreshTokenRepository authRefreshTokenRepository;
     // presigned URL 유효 시간: 클라이언트 세션 내 이미지 표시에 충분한 시간으로 설정
     private static final Duration PROFILE_IMAGE_URL_EXPIRATION = Duration.ofMinutes(10);
 
@@ -118,5 +124,38 @@ public class UserService {
         } catch (ApiException e) {
             return null;
         }
+    }
+
+    // 회원 탈퇴 처리 (Soft Delete)
+    // 처리 순서: 탈퇴 사유 저장 → 닉네임 변경 + 상태 변경 → 토큰 철회
+    // 모든 처리는 단일 트랜잭션으로 수행하여 부분 실패를 방지
+    @Transactional
+    public void withdrawUser(Long userId, UserWithdrawalRequest request) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. 이미 탈퇴한 사용자 차단
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            throw new ApiException(ErrorCode.USER_ALREADY_WITHDRAWN);
+        }
+
+        // 3. 탈퇴 사유 저장
+        // user_id UNIQUE 제약이 DB에서 중복 삽입을 구조적으로 방지
+        UserWithdrawal withdrawal = UserWithdrawal.builder()
+                .user(user)
+                .reason(request.getReason())
+                .build();
+        userWithdrawalRepository.save(withdrawal);
+
+        // 4. 닉네임 변경 + 상태 WITHDRAWN + deleted_at 설정
+        // deleted_{userId}_{원본닉네임} 패턴으로 변경하여 UNIQUE 제약 해제
+        // 재가입 시 동일 닉네임 사용 가능하도록 처리
+        user.applyWithdrawalNicknamePattern();
+
+        // 5. 모든 유효한 Refresh Token 철회
+        // 탈퇴 후 기존 토큰으로 재인증을 원천 차단
+        authRefreshTokenRepository.findByUser_UserIdAndRevokedAtIsNull(userId)
+                .forEach(token -> token.revoke());
     }
 }


### PR DESCRIPTION
# Feat : DELETE /api/v1/users/me 회원 탈퇴 API 구현

---

## 작업 내용

### **커밋 1: User 엔티티에 탈퇴 처리 메서드 추가**

- `applyWithdrawalNicknamePattern()` 추가
- 닉네임을 `deleted_{userId}_{원본닉네임}` 패턴으로 변경
- `status = WITHDRAWN`, `deletedAt = now()` 설정
- VARCHAR(30) 초과 시 truncate 처리

### **커밋 2: UserWithdrawal 엔티티 추가**

- `user_withdrawals` 테이블 매핑 (V1__init.sql 기존 테이블, 마이그레이션 없음)
- `user_id` UNIQUE 제약으로 유저당 1회 탈퇴 기록 보장

### **커밋 3: UserWithdrawalRepository 추가**

- `existsByUser_UserId()` 메서드 포함

### **커밋 4: 회원 탈퇴 요청 DTO 추가**

- `UserWithdrawalRequest` 생성
- `reason` 필수값 (`@NotBlank`), 최대 1000자 제한

### **커밋 5: UserService에 회원 탈퇴 로직 추가**

- `withdrawUser()` 메서드 구현
- 탈퇴 사유 저장 → 닉네임 패턴 변경 → 토큰 철회 단일 트랜잭션 처리

### **커밋 6: 회원 탈퇴 API 엔드포인트 추가**

- `DELETE /api/v1/users/me` 엔드포인트 추가

---

## 설계 의도

### **왜 Soft Delete인가?**

물리 삭제 시 연관된 채팅 메시지, 지원 이력 등 다른 테이블의 FK 참조가 끊어집니다. Soft Delete로 처리하면 데이터 무결성을 유지하면서 탈퇴 처리가 가능하고, 향후 탈퇴 사용자 데이터 처리 정책(익명화, 표시 유지 등)을 유연하게 결정할 수 있습니다.

### **왜 닉네임을 패턴으로 변경하는가?**

`users.nickname`에 UNIQUE 제약이 있기 때문에, 탈퇴 후 동일한 카카오 계정(또는 다른 사람)이 같은 닉네임으로 재가입하려 할 때 충돌이 발생합니다. `deleted_{userId}_{원본닉네임}` 패턴으로 변경하면 원본 닉네임을 해제하면서도 탈퇴 기록임을 식별할 수 있습니다.

### **카카오 연동 해제(unlink) 미적용 이유**

현재 시스템은 카카오 access token을 저장하지 않아 unlink API 호출이 불가합니다. 서비스 내 Soft Delete만으로 탈퇴 처리를 완료하며, 카카오 연동 해제는 추후 토큰 저장 방식 논의 후 별도 작업으로 진행합니다.

### **단일 트랜잭션 처리 의도**

탈퇴 사유 저장, 닉네임 변경, 토큰 철회 중 하나라도 실패하면 전체가 롤백됩니다. 예를 들어 토큰 철회는 됐는데 상태 변경이 안 된 경우 같은 불일치 상황을 방지합니다.

---

## API 명세

### DELETE /api/v1/users/me

**설명**: 현재 로그인한 사용자의 회원 탈퇴를 처리합니다.

**권한**: 인증 필요 (Access Token)

**요청 Body**:

| 필드 | 타입 | 필수 | 설명 |
|------|------|------|------|
| reason | String | O | 탈퇴 사유 (최대 1000자) |

**요청 예시**:
```json
{ "reason": "서비스를 더 이상 이용하지 않을 것 같아서요." }
```

**성공 응답 (200 OK)**:
```json
{
  "status": 200,
  "code": "USER_003",
  "message": "회원 탈퇴가 완료되었습니다.",
  "data": null
}
```

**실패 응답**:

`403 FORBIDDEN` — 이미 탈퇴한 사용자:
```json
{ "status": 403, "code": "USER_003", "message": "이미 탈퇴한 사용자입니다.", "data": null }
```

`400 BAD_REQUEST` — 탈퇴 사유 미입력:
```json
{ "status": 400, "code": "VALIDATION_FAILED", "message": "요청 값이 올바르지 않습니다.", "data": null }
```

---

## 비즈니스 플로우
```
1. 클라이언트 요청
   ↓ DELETE /api/v1/users/me
   ↓ Body: { "reason": "..." }

2. JwtAuthenticationFilter → UserPrincipal 생성

3. UserController.withdrawCurrentUser()
   ↓ @Valid 검증 (reason 필수)

4. UserService.withdrawUser(userId, request) [단일 트랜잭션]
   ↓ UserRepository.findById() → 사용자 조회
   ↓ WITHDRAWN 체크 → 403
   ↓ UserWithdrawalRepository.save() → 탈퇴 사유 저장
   ↓ user.applyWithdrawalNicknamePattern() → 닉네임 변경 + 상태 변경 + deleted_at
   ↓ authRefreshTokenRepository → 모든 유효 토큰 revoke()

5. 응답 반환
   ↓ 200 "회원 탈퇴가 완료되었습니다."

6. 클라이언트
   ↓ 로컬 토큰 삭제 + 로그인 화면 이동
```
```