### PR TITLE
feat: 로컬 전용 docker compose 파일 추가.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+#--- proxy ---
+# private subnet에 있는 리소스에 접근하기 위해 프록시가 필요한 경우, 다음과 같이 설정할 수 있습니다.                                                   
+# JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=<proxy-ip> -Dhttp.proxyPort=3128 -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=localhost|127.*|10.*|*.amazonaws.com
+
 # --- DATABASE ---
 DB_HOST=localhost
 DB_PORT=3306
@@ -15,9 +19,6 @@ AI_SERVICE_URL=http://localhost:8000
 
 # --- Application ---
 APP_FRONTEND_URL=http://localhost:3000
-
-#--- proxy ---                                                      
-JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=<proxy-ip> -Dhttp.proxyPort=3128 -Dhttps.proxyHost=<proxy-ip> -Dhttps.proxyPort=3128 -Dhttp.nonProxyHosts=localhost|127.*|10.*|*.amazonaws.com
 
 #--- RABBITMQ ---
 RABBITMQ_HOST=insert-your-rabbitmq-host (local: localhost)

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,68 @@
+services:
+  ## MYSQL
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-password}
+      MYSQL_DATABASE: ${DB_SCHEMA:-example}
+      MYSQL_USER: ${DB_USERNAME:-root}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-password}
+    ports:
+      - "${DB_PORT:-3306}:3306"
+
+  ## RabbitMQ
+  rabbitmq:
+    image: rabbitmq:3-management
+    restart: always
+    container_name: rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USERNAME:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-guest}
+    ports:
+      - "${RABBITMQ_PORT:-5672}:5672"
+      - "15672:15672"
+
+  ## Backend
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: backend
+    ports:
+      - "8080:8080"
+      - "9101:9101"
+    depends_on:
+      - mysql
+      - rabbitmq
+    env_file:
+      - .env
+
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
+      JAVA_OPTS: ${JAVA_OPTS:-}
+      TZ: Asia/Seoul
+      DB_HOST: mysql
+      RABBITMQ_HOST: rabbitmq
+    restart: unless-stopped
+
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:9101/actuator/health >/dev/null || exit 1",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 20s
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+        tag: "{{.Name}}"
+
+    stop_grace_period: 30s


### PR DESCRIPTION
## 요약
- 로컬 개발의 편의성을 위해서 로컬 전용 docker compose 파일을 추가하였습니다.
- .env.example 프록시 관련 설명을 추가하였습니다.

## 사용방법 
.env.example 기반으로 .env 파일을 작성합니다.
Mysql, RabbitMQ 엔드포인트 경로는 각각 mysql, rabbitmq로 작성하면 됩니다.( 도커 컨테이너 환경에서는 localhost으로 호출이 되지 않습니다.)

루트 디렉토리에서 다음 명령어를 실행합니다.

```bash
$ docker-compose --file docker-compose.local.yml up  
```

## 팀 온보딩
develop 프로필로 실행되는데 핫리로딩이 적용되어있는지는 확인하지 못했습니다. 일단 개발하시던 방식으로 개발하시면 됩니다.
리암께선 유용하게 사용하실 수 있을 것 같습니다.