### PR TITLE
fix: refresh SecurityConfig permitAll 누락 수정

### DIFF
--- a/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
+++ b/src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java
@@ -87,6 +87,10 @@ public class SecurityConfig {
 
                         // 카카오 OAuth 관련 URL은 모두 퍼블릭 허용
                         .requestMatchers("/api/v1/auth/kakao/**").permitAll()
+                        // 토큰 재발급은 accessToken이 만료된 상태에서 호출되므로 인증 없이 허용
+                        // JwtAuthenticationFilter가 먼저 실행되어 만료된 accessToken을 거부하면
+                        // refresh 엔드포인트까지 도달하지 못해 401이 반환되는 문제를 방지
+                        .requestMatchers("/api/v1/auth/refresh").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/job-postings").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/job-postings/{jobMasterId}").permitAll()
                         // 헬스 체크는 퍼블릭 허용


### PR DESCRIPTION
accessToken 만료 상태에서 refresh 호출 시
JwtAuthenticationFilter가 먼저 실행되어 401을 반환하는 문제 수정

## 개요

`/api/v1/auth/refresh` 엔드포인트가 SecurityConfig의 permitAll 목록에 누락되어
accessToken 만료 상태에서 토큰 재발급 요청 시 401이 반환되는 버그를 수정합니다.

---

## 문제 원인
```
POST /api/v1/auth/refresh
    ↓
JwtAuthenticationFilter 실행
    ↓
accessToken 만료 → 401 반환  ← 여기서 차단
    ↓
refresh 엔드포인트 도달 못함
```

`/api/v1/auth/kakao/**` 만 permitAll로 설정되어 있어
`/api/v1/auth/refresh`는 JwtAuthenticationFilter를 먼저 통과해야 했습니다.
그러나 refresh 호출 시점은 accessToken이 이미 만료된 상태이므로
필터에서 401을 반환하고 엔드포인트까지 도달하지 못했습니다.

---

## 변경 내용

**`SecurityConfig.java`**
```java
// Before
.requestMatchers("/api/v1/auth/kakao/**").permitAll()

// After
.requestMatchers("/api/v1/auth/kakao/**").permitAll()
.requestMatchers("/api/v1/auth/refresh").permitAll()
```

---

## 변경 파일

- `src/main/java/com/thunder11/scuad/common/config/SecurityConfig.java`