### PR TITLE
AI 지원자간 비교 비동기 rebbitmq 전환

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -379,6 +379,7 @@ public class ChatRoomController {
     }
 
     // 채팅방 멤버와 AI 비교 분석 요청 (비동기)
+    @ResponseStatus(HttpStatus.ACCEPTED)
     @PostMapping("/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}/comparison")
     public ApiResponse<Void> requestComparison(
             @PathVariable Long chatRoomId,

--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -378,9 +378,32 @@ public class ChatRoomController {
         );
     }
 
-    // 채팅방 멤버와 나의 AI 비교 분석
+    // 채팅방 멤버와 AI 비교 분석 요청 (비동기)
+    @PostMapping("/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}/comparison")
+    public ApiResponse<Void> requestComparison(
+            @PathVariable Long chatRoomId,
+            @PathVariable Long chatRoomMemberId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        log.info("POST /api/v1/chat-rooms/{}/members/{}/comparison - userId={}",
+                chatRoomId, chatRoomMemberId, userPrincipal.getUserId());
+
+        chatMemberComparisonService.requestComparison(
+                chatRoomId,
+                userPrincipal.getUserId(),
+                chatRoomMemberId
+        );
+
+        return ApiResponse.of(
+                HttpStatus.ACCEPTED.value(),
+                "COMPARISON_REQUESTED",
+                "비교 분석 요청이 접수되었습니다. 잠시 후 결과를 조회해주세요."
+        );
+    }
+
+    // 채팅방 멤버와 AI 비교 분석 결과 조회
     @GetMapping("/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}/comparison")
-    public ApiResponse<ComparisonResponse> compareWithMember(
+    public ApiResponse<ComparisonResponse> getComparisonResult(
             @PathVariable Long chatRoomId,
             @PathVariable Long chatRoomMemberId,
             @AuthenticationPrincipal UserPrincipal userPrincipal
@@ -388,7 +411,7 @@ public class ChatRoomController {
         log.info("GET /api/v1/chat-rooms/{}/members/{}/comparison - userId={}",
                 chatRoomId, chatRoomMemberId, userPrincipal.getUserId());
 
-        ComparisonResponse response = chatMemberComparisonService.compare(
+        ComparisonResponse response = chatMemberComparisonService.getComparisonResult(
                 chatRoomId,
                 userPrincipal.getUserId(),
                 chatRoomMemberId

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java
@@ -1,6 +1,6 @@
 package com.thunder11.scuad.chat.service;
 
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,12 +15,11 @@ import com.thunder11.scuad.chat.repository.ChatRoomMemberRepository;
 import com.thunder11.scuad.chat.repository.ChatRoomRepository;
 import com.thunder11.scuad.common.exception.ApiException;
 import com.thunder11.scuad.common.exception.ErrorCode;
-import com.thunder11.scuad.infra.rabbitmq.config.RabbitMQConfig;
-import com.thunder11.scuad.infra.rabbitmq.dto.AiRequestMessage;
 import com.thunder11.scuad.jobposting.domain.AiEvalJob;
 import com.thunder11.scuad.jobposting.domain.JobApplication;
 import com.thunder11.scuad.jobposting.domain.type.AiJobStatus;
 import com.thunder11.scuad.jobposting.domain.type.AnalysisType;
+import com.thunder11.scuad.jobposting.event.AiComparisonCreateEvent;
 import com.thunder11.scuad.jobposting.repository.AiApplicantComparisonRepository;
 import com.thunder11.scuad.jobposting.repository.AiEvalJobRepository;
 import com.thunder11.scuad.jobposting.repository.JobApplicationRepository;
@@ -36,7 +35,7 @@ public class ChatMemberComparisonService {
     private final AiApplicantComparisonRepository aiApplicantComparisonRepository;
     private final AiEvalJobRepository aiEvalJobRepository;
     private final UserRepository userRepository;
-    private final RabbitTemplate rabbitTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * AI 비교 분석 요청 — 비동기 (POST 전용)
@@ -102,22 +101,17 @@ public class ChatMemberComparisonService {
         savedJob.startProcessing();
         aiEvalJobRepository.save(savedJob);
 
-        // 9. RabbitMQ 메시지 발행
-        //    AI 호출을 큐에 위임하고 즉시 반환하여 요청 스레드를 해제한다
-        AiRequestMessage message = AiRequestMessage.builder()
-                .evalJobId(String.valueOf(savedJob.getId()))
-                .userId(String.valueOf(myApplication.getUser().getUserId()))
-                .jobPostingId(String.valueOf(myApplication.getJobMaster().getId()))
-                .competitor(String.valueOf(competitorApplication.getUser().getUserId()))
-                .build();
-
-        rabbitTemplate.convertAndSend(
-                RabbitMQConfig.EXCHANGE_NAME,
-                RabbitMQConfig.QUEUE_COMPARISON,
-                message
-        );
-        log.info("RabbitMQ 발송 완료: evalJobId={}, queue={}",
-                savedJob.getId(), RabbitMQConfig.QUEUE_COMPARISON);
+        // 9. 이벤트 발행
+        //    트랜잭션 커밋 후 AiEvaluationWorker의 @TransactionalEventListener(AFTER_COMMIT)가 수신하여 MQ 발행.
+        //    트랜잭션 내부에서 직접 MQ를 발행하면 DB 롤백 시에도 메시지가 발행되는 문제가 있으므로
+        //    커밋 확정 후에 발행을 위임하는 방식을 사용한다.
+        eventPublisher.publishEvent(new AiComparisonCreateEvent(
+                savedJob.getId(),
+                myApplication.getUser().getUserId(),
+                myApplication.getJobMaster().getId(),
+                competitorApplication.getUser().getUserId()
+        ));
+        log.info("비교 분석 이벤트 발행 완료: evalJobId={}", savedJob.getId());
     }
 
     /**

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMemberComparisonService.java
@@ -1,32 +1,30 @@
 package com.thunder11.scuad.chat.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.thunder11.scuad.auth.domain.User;
+import com.thunder11.scuad.auth.repository.UserRepository;
 import com.thunder11.scuad.chat.domain.ChatRoomMember;
 import com.thunder11.scuad.chat.dto.response.ComparisonResponse;
 import com.thunder11.scuad.chat.repository.ChatRoomMemberRepository;
 import com.thunder11.scuad.chat.repository.ChatRoomRepository;
 import com.thunder11.scuad.common.exception.ApiException;
 import com.thunder11.scuad.common.exception.ErrorCode;
-import com.thunder11.scuad.infra.ai.client.AiServiceClient;
-import com.thunder11.scuad.infra.ai.dto.request.AiCompareRequest;
-import com.thunder11.scuad.infra.ai.dto.response.AiCompareResponse;
-import com.thunder11.scuad.jobposting.domain.AiApplicantComparison;
-import com.thunder11.scuad.jobposting.domain.ComparisonMetric;
+import com.thunder11.scuad.infra.rabbitmq.config.RabbitMQConfig;
+import com.thunder11.scuad.infra.rabbitmq.dto.AiRequestMessage;
+import com.thunder11.scuad.jobposting.domain.AiEvalJob;
 import com.thunder11.scuad.jobposting.domain.JobApplication;
-import com.thunder11.scuad.jobposting.domain.JobMaster;
+import com.thunder11.scuad.jobposting.domain.type.AiJobStatus;
+import com.thunder11.scuad.jobposting.domain.type.AnalysisType;
 import com.thunder11.scuad.jobposting.repository.AiApplicantComparisonRepository;
+import com.thunder11.scuad.jobposting.repository.AiEvalJobRepository;
 import com.thunder11.scuad.jobposting.repository.JobApplicationRepository;
 
-// 채팅방 멤버 간 AI 비교 분석 서비스
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -36,12 +34,21 @@ public class ChatMemberComparisonService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final JobApplicationRepository jobApplicationRepository;
     private final AiApplicantComparisonRepository aiApplicantComparisonRepository;
-    private final AiServiceClient aiServiceClient;
-    private final AiComparisonSaveHelper aiComparisonSaveHelper;
+    private final AiEvalJobRepository aiEvalJobRepository;
+    private final UserRepository userRepository;
+    private final RabbitTemplate rabbitTemplate;
 
+    /**
+     * AI 비교 분석 요청 — 비동기 (POST 전용)
+     *
+     * 기존 동기 구조에서는 AI 호출 응답까지 스레드를 점유했으나,
+     * 비동기 전환 후에는 AiEvalJob 생성 + RabbitMQ 메시지 발행만 수행하고 즉시 반환한다.
+     * 실제 AI 처리 및 DB 저장은 AI 서버가 큐를 소비한 뒤 /api/internal/ai/callback으로
+     * 결과를 전달하면 AiResultProcessingService가 처리한다.
+     */
     @Transactional
-    public ComparisonResponse compare(Long chatRoomId, Long requestUserId, Long chatRoomMemberId) {
-        log.info("비교 요청: chatRoomId={}, requestUserId={}, targetMemberId={}",
+    public void requestComparison(Long chatRoomId, Long requestUserId, Long chatRoomMemberId) {
+        log.info("비교 분석 요청: chatRoomId={}, requestUserId={}, targetMemberId={}",
                 chatRoomId, requestUserId, chatRoomMemberId);
 
         // 1. 채팅방 존재 확인
@@ -77,63 +84,90 @@ public class ChatMemberComparisonService {
                 .findById(targetMember.getJobApplicationId())
                 .orElseThrow(() -> new ApiException(ErrorCode.JOB_APPLICATION_NOT_FOUND));
 
-        // 7. DB에 기존 비교 결과 있으면 바로 반환 (AI 중복 호출 방지)
+        // 7. 요청자 User 조회 (AiEvalJob.requestedBy 필드용)
+        User requestUser = userRepository.findById(requestUserId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        // 8. AiEvalJob 생성
+        //    COMPARISON 타입은 콜백 수신 시 my + competitor 두 지원 ID가 모두 필요하므로
+        //    competitorApplication을 함께 저장한다
+        AiEvalJob evalJob = AiEvalJob.builder()
+                .jobApplication(myApplication)
+                .competitorApplication(competitorApplication)
+                .requestedBy(requestUser)
+                .analysisType(AnalysisType.COMPARISON)
+                .status(AiJobStatus.PENDING)
+                .build();
+        AiEvalJob savedJob = aiEvalJobRepository.save(evalJob);
+        savedJob.startProcessing();
+        aiEvalJobRepository.save(savedJob);
+
+        // 9. RabbitMQ 메시지 발행
+        //    AI 호출을 큐에 위임하고 즉시 반환하여 요청 스레드를 해제한다
+        AiRequestMessage message = AiRequestMessage.builder()
+                .evalJobId(String.valueOf(savedJob.getId()))
+                .userId(String.valueOf(myApplication.getUser().getUserId()))
+                .jobPostingId(String.valueOf(myApplication.getJobMaster().getId()))
+                .competitor(String.valueOf(competitorApplication.getUser().getUserId()))
+                .build();
+
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.EXCHANGE_NAME,
+                RabbitMQConfig.QUEUE_COMPARISON,
+                message
+        );
+        log.info("RabbitMQ 발송 완료: evalJobId={}, queue={}",
+                savedJob.getId(), RabbitMQConfig.QUEUE_COMPARISON);
+    }
+
+    /**
+     * AI 비교 분석 결과 조회 — GET 전용
+     *
+     * 비동기 전환 후 이 메서드는 결과 조회만 담당한다.
+     * AI 처리가 아직 완료되지 않아 DB에 결과가 없으면 COMPARISON_RESULT_NOT_FOUND(404)를 반환하며,
+     * 클라이언트는 이 응답을 받으면 잠시 후 재조회(폴링)하면 된다.
+     */
+    @Transactional(readOnly = true)
+    public ComparisonResponse getComparisonResult(Long chatRoomId, Long requestUserId, Long chatRoomMemberId) {
+        log.info("비교 결과 조회: chatRoomId={}, requestUserId={}, targetMemberId={}",
+                chatRoomId, requestUserId, chatRoomMemberId);
+
+        // 1. 채팅방 존재 확인
+        chatRoomRepository.findByIdNotDeleted(chatRoomId)
+                .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 2. 요청자가 채팅방 멤버인지 확인
+        ChatRoomMember myMember = chatRoomMemberRepository
+                .findByChatRoomIdAndUserIdAndKickedAtIsNull(chatRoomId, requestUserId)
+                .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_ACCESS_DENIED));
+
+        // 3. 비교 대상 멤버 조회
+        ChatRoomMember targetMember = chatRoomMemberRepository
+                .findByChatRoomMemberIdAndKickedAtIsNull(chatRoomMemberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
+
+        // 4. 대상 멤버가 같은 채팅방 소속인지 검증
+        if (!targetMember.getChatRoomId().equals(chatRoomId)) {
+            throw new ApiException(ErrorCode.CHAT_MEMBER_NOT_FOUND);
+        }
+
+        // 5. 지원서 조회
+        JobApplication myApplication = jobApplicationRepository
+                .findById(myMember.getJobApplicationId())
+                .orElseThrow(() -> new ApiException(ErrorCode.JOB_APPLICATION_NOT_FOUND));
+
+        JobApplication competitorApplication = jobApplicationRepository
+                .findById(targetMember.getJobApplicationId())
+                .orElseThrow(() -> new ApiException(ErrorCode.JOB_APPLICATION_NOT_FOUND));
+
+        // 6. 비교 결과 조회
+        //    AI 처리가 완료되지 않은 경우 404 반환 → 클라이언트 폴링 유도
         return aiApplicantComparisonRepository
                 .findByMyApplication_IdAndCompetitorApplication_Id(
                         myApplication.getId(),
                         competitorApplication.getId()
                 )
                 .map(ComparisonResponse::from)
-                .orElseGet(() -> callAiAndSave(myApplication, competitorApplication));
-    }
-
-    // AI 비교 API 호출 후 결과 저장
-    private ComparisonResponse callAiAndSave(
-            JobApplication myApplication,
-            JobApplication competitorApplication
-    ) {
-        JobMaster jobMaster = myApplication.getJobMaster();
-
-        // AI 서버에 비교 요청
-        AiCompareRequest aiRequest = AiCompareRequest.builder()
-                .jobPostingId(String.valueOf(jobMaster.getId()))
-                .userId(String.valueOf(myApplication.getUser().getUserId()))
-                .competitor(String.valueOf(competitorApplication.getUser().getUserId()))
-                .build();
-
-        AiCompareResponse aiResponse = aiServiceClient.compareApplicants(aiRequest);
-
-        // AI 응답을 도메인 객체로 변환
-        List<ComparisonMetric> metrics = aiResponse.getComparisonMetrics().stream()
-                .map(m -> new ComparisonMetric(m.getName(), m.getMyScore(), m.getCompetitorScore()))
-                .collect(Collectors.toList());
-
-        AiApplicantComparison comparison = AiApplicantComparison.builder()
-                .jobMaster(jobMaster)
-                .myApplication(myApplication)
-                .competitorApplication(competitorApplication)
-                .comparisonMetrics(metrics)
-                .strengthsReport(aiResponse.getStrengthsReport())
-                .weaknessesReport(aiResponse.getWeaknessesReport())
-                .build();
-
-        // race condition 대비: UNIQUE 제약 위반 시 이미 저장된 결과를 조회해서 반환
-        // REQUIRES_NEW 독립 트랜잭션으로 분리한 이유:
-        //   같은 트랜잭션 안에서 예외 발생 시 JPA 세션이 오염(rollback-only)되어
-        //   catch 후 findBy 시도 시 AssertionFailure 발생 → 이슈11과 동일한 문제
-        //   REQUIRES_NEW로 분리하면 예외 발생 시 내부 트랜잭션만 롤백되고
-        //   외부 세션은 깨끗하게 유지되어 findBy가 정상 동작함
-        try {
-            AiApplicantComparison saved = aiComparisonSaveHelper.trySave(comparison);
-            return ComparisonResponse.from(saved);
-        } catch (DataIntegrityViolationException e) {
-            log.warn("AI 비교 결과 중복 저장 감지, 기존 결과 반환: myApplicationId={}, competitorApplicationId={}",
-                    myApplication.getId(), competitorApplication.getId());
-            return aiApplicantComparisonRepository
-                    .findByMyApplication_IdAndCompetitorApplication_Id(
-                            myApplication.getId(), competitorApplication.getId())
-                    .map(ComparisonResponse::from)
-                    .orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_ERROR));
-        }
+                .orElseThrow(() -> new ApiException(ErrorCode.COMPARISON_RESULT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
+++ b/src/main/java/com/thunder11/scuad/common/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "USER_002", "이미 사용 중인 닉네임입니다."),
     USER_ALREADY_WITHDRAWN(HttpStatus.FORBIDDEN, "USER_003", "이미 탈퇴한 사용자입니다."),
     COMPARISON_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "COMPARISON_SELF_NOT_ALLOWED", "자기 자신과는 비교할 수 없습니다."),
+    COMPARISON_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPARISON_RESULT_NOT_FOUND", "비교 분석 결과가 아직 준비되지 않았습니다. 잠시 후 다시 조회해주세요."),
     DOCUMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "DOCUMENT_NOT_FOUND", "제출된 문서가 없습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/thunder11/scuad/infra/rabbitmq/dto/AiRequestMessage.java
+++ b/src/main/java/com/thunder11/scuad/infra/rabbitmq/dto/AiRequestMessage.java
@@ -18,4 +18,9 @@ public class AiRequestMessage {
     private String userId;
     @JsonProperty("job_posting_id")
     private String jobPostingId;
+    // COMPARISON 타입 전용: 비교 대상 사용자 ID
+    // AI 서버가 두 지원자를 비교하려면 경쟁자 ID가 필요하므로 추가.
+    // EVALUATION/RESUME/PORTFOLIO 요청 시에는 null로 전송되며 기존 동작에 영향 없음.
+    @JsonProperty("competitor")
+    private String competitor;
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/domain/AiEvalJob.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/domain/AiEvalJob.java
@@ -43,6 +43,14 @@ public class AiEvalJob {
     @JoinColumn(name = "job_application_id", nullable = false)
     private JobApplication jobApplication;
 
+    // COMPARISON 타입 전용: 비교 대상 지원자의 지원 ID
+    // AI 콜백 수신 시 ai_applicant_comparison 저장에 my + competitor 두 값이 모두 필요하므로
+    // AiEvalJob 생성 시점에 함께 저장한다.
+    // EVALUATION/RESUME/PORTFOLIO 타입에서는 사용하지 않으므로 nullable
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "competitor_application_id", nullable = true)
+    private JobApplication competitorApplication;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "requested_by", nullable = false)
     private User requestedBy;
@@ -63,8 +71,10 @@ public class AiEvalJob {
     private LocalDateTime createdAt;
 
     @Builder
-    public AiEvalJob(JobApplication jobApplication, User requestedBy, AnalysisType analysisType, AiJobStatus status) {
+    public AiEvalJob(JobApplication jobApplication, JobApplication competitorApplication,
+                     User requestedBy, AnalysisType analysisType, AiJobStatus status) {
         this.jobApplication = jobApplication;
+        this.competitorApplication = competitorApplication;
         this.requestedBy = requestedBy;
         this.analysisType = analysisType;
         this.status = status;

--- a/src/main/java/com/thunder11/scuad/jobposting/event/AiComparisonCreateEvent.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/event/AiComparisonCreateEvent.java
@@ -1,0 +1,15 @@
+package com.thunder11.scuad.jobposting.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AiComparisonCreateEvent {
+
+    // AiEvalJob PK — 트랜잭션 커밋 후 MQ 발행 시 evalJobId로 바로 조회하기 위해 사용
+    private final Long evalJobId;
+    private final Long userId;
+    private final Long jobPostingId;
+    private final Long competitorUserId;
+}

--- a/src/main/java/com/thunder11/scuad/jobposting/service/AiEvaluationWorker.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/AiEvaluationWorker.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import com.thunder11.scuad.infra.rabbitmq.config.RabbitMQConfig;
 import com.thunder11.scuad.infra.rabbitmq.dto.AiRequestMessage;
 import com.thunder11.scuad.jobposting.event.AiAnalysisCreateEvent;
+import com.thunder11.scuad.jobposting.event.AiComparisonCreateEvent;
 import com.thunder11.scuad.jobposting.domain.*;
 import com.thunder11.scuad.jobposting.repository.*;
 import com.thunder11.scuad.jobposting.domain.type.AnalysisType;
@@ -50,6 +51,31 @@ public class AiEvaluationWorker {
 
         rabbitTemplate.convertAndSend(RabbitMQConfig.EXCHANGE_NAME, routingKey, message);
         log.info("RabbitMQ 발송 완료 - Queue: {}, evalJobId: {}", routingKey, aiEvalJob.getId());
+    }
+
+    // COMPARISON 타입 전용 핸들러
+    // 기존 AiAnalysisCreateEvent와 분리한 이유:
+    //   COMPARISON은 competitor 정보가 추가로 필요하며,
+    //   AiEvalJob이 이미 생성된 상태에서 이벤트를 발행하므로
+    //   evalJobId로 직접 조회하는 방식을 사용한다.
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void processComparisonAsync(AiComparisonCreateEvent event) {
+        log.info("AI 비교 분석 작업 시작: evalJobId={}, userId={}, competitorUserId={}",
+                event.getEvalJobId(), event.getUserId(), event.getCompetitorUserId());
+
+        AiEvalJob aiEvalJob = aiEvalJobRepository.findById(event.getEvalJobId())
+                .orElseThrow(() -> new IllegalStateException("AI 비교 분석 작업을 찾을 수 없습니다. ID=" + event.getEvalJobId()));
+
+        AiRequestMessage message = AiRequestMessage.builder()
+                .evalJobId(String.valueOf(aiEvalJob.getId()))
+                .userId(String.valueOf(event.getUserId()))
+                .jobPostingId(String.valueOf(event.getJobPostingId()))
+                .competitor(String.valueOf(event.getCompetitorUserId()))
+                .build();
+
+        rabbitTemplate.convertAndSend(RabbitMQConfig.EXCHANGE_NAME, RabbitMQConfig.QUEUE_COMPARISON, message);
+        log.info("RabbitMQ 발송 완료 - Queue: {}, evalJobId: {}", RabbitMQConfig.QUEUE_COMPARISON, aiEvalJob.getId());
     }
 
     private String getQueueNameByType(AnalysisType type) {

--- a/src/main/java/com/thunder11/scuad/jobposting/service/AiResultProcessingService.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/AiResultProcessingService.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.thunder11.scuad.infra.ai.dto.response.AiCompareResponse;
 import com.thunder11.scuad.infra.ai.dto.response.AiEvaluationResultResponse;
 import com.thunder11.scuad.infra.ai.dto.response.AiPortfolioAnalysisResponse;
 import com.thunder11.scuad.infra.ai.dto.response.AiResumeAnalysisResponse;
@@ -28,6 +29,7 @@ public class AiResultProcessingService {
     private final AiApplicationEvaluationRepository aiApplicationEvaluationRepository;
     private final AiResumeAnalysisRepository aiResumeAnalysisRepository;
     private final AiPortfolioAnalysisRepository aiPortfolioAnalysisRepository;
+    private final AiApplicantComparisonRepository aiApplicantComparisonRepository;
     private final JobMasterRepository jobMasterRepository;
     private final ObjectMapper objectMapper;
     private final NotificationService notificationService;
@@ -58,6 +60,13 @@ public class AiResultProcessingService {
                     AiPortfolioAnalysisResponse result = objectMapper.treeToValue(response.getData(), AiPortfolioAnalysisResponse.class);
                     savePortfolioResult(aiEvalJob.getJobApplication(), result);
                 }
+                case COMPARISON -> {
+                    // COMPARISON 타입은 my + competitor 두 지원이 모두 필요.
+                    // AiEvalJob 생성 시 competitorApplication을 함께 저장해두었으므로
+                    // 콜백 수신 시점에 별도 조회 없이 바로 저장 가능.
+                    AiCompareResponse result = objectMapper.treeToValue(response.getData(), AiCompareResponse.class);
+                    saveComparisonResult(aiEvalJob.getJobApplication(), aiEvalJob.getCompetitorApplication(), result);
+                }
                 default -> throw new IllegalArgumentException("지원하지 않는 분석 타입: " + aiEvalJob.getAnalysisType());
             }
             aiEvalJob.complete();
@@ -72,6 +81,7 @@ public class AiResultProcessingService {
                 case EVALUATION ->  "AI_EVAL_COMPLETE";
                 case RESUME -> "RESUME_COMPLETE";
                 case PORTFOLIO -> "PORTFOLIO_COMPLETE";
+                case COMPARISON -> "COMPARISON_COMPLETE";
                 default -> "ANALYSIS_COMPLETE";
             };
 
@@ -85,6 +95,35 @@ public class AiResultProcessingService {
             aiEvalJob.fail(e.getMessage());
             aiEvalJobRepository.save(aiEvalJob);
         }
+    }
+
+    private void saveComparisonResult(JobApplication myApplication,
+                                       AiCompareResponse result) {
+        List<ComparisonMetric> metrics = result.getComparisonMetrics().stream()
+                .map(m -> new ComparisonMetric(m.getName(), m.getMyScore(), m.getCompetitorScore()))
+                .collect(Collectors.toList());
+
+        // UNIQUE 제약(my_application_id, competitor_application_id)으로
+        // 동일 조합 중복 저장은 DB 레벨에서 방지됨
+        aiApplicantComparisonRepository.findByMyApplication_IdAndCompetitorApplication_Id(
+                myApplication.getId(), competitorApplication.getId()
+        ).ifPresentOrElse(
+                existing -> log.info("비교 결과 이미 존재, 저장 생략: myApplicationId={}, competitorApplicationId={}",
+                        myApplication.getId(), competitorApplication.getId()),
+                () -> {
+                    AiApplicantComparison comparison = AiApplicantComparison.builder()
+                            .jobMaster(myApplication.getJobMaster())
+                            .myApplication(myApplication)
+                            .competitorApplication(competitorApplication)
+                            .comparisonMetrics(metrics)
+                            .strengthsReport(result.getStrengthsReport())
+                            .weaknessesReport(result.getWeaknessesReport())
+                            .build();
+                    aiApplicantComparisonRepository.save(comparison);
+                    log.info("AI 비교 결과 저장 완료: myApplicationId={}, competitorApplicationId={}",
+                            myApplication.getId(), competitorApplication.getId());
+                }
+        );
     }
 
     private void saveEvaluationResult(JobApplication application, AiEvaluationResultResponse result) {

--- a/src/main/java/com/thunder11/scuad/jobposting/service/AiResultProcessingService.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/AiResultProcessingService.java
@@ -98,6 +98,7 @@ public class AiResultProcessingService {
     }
 
     private void saveComparisonResult(JobApplication myApplication,
+                                       JobApplication competitorApplication,
                                        AiCompareResponse result) {
         List<ComparisonMetric> metrics = result.getComparisonMetrics().stream()
                 .map(m -> new ComparisonMetric(m.getName(), m.getMyScore(), m.getCompetitorScore()))

--- a/src/main/resources/db/migration/V6__add_competitor_application_id_to_ai_eval_jobs.sql
+++ b/src/main/resources/db/migration/V6__add_competitor_application_id_to_ai_eval_jobs.sql
@@ -1,0 +1,12 @@
+-- COMPARISON 타입 비동기 처리를 위해 ai_eval_jobs에 competitor_application_id 추가
+--
+-- 추가 이유:
+--   AI 비교 분석 비동기 전환 시 콜백(/api/internal/ai/callback) 수신 시점에
+--   ai_applicant_comparison 저장을 위해 my_application_id + competitor_application_id
+--   두 값이 모두 필요하다. eval_job_id만으로는 my_application_id만 식별 가능하므로
+--   COMPARISON 타입 AiEvalJob 생성 시 경쟁자 지원 ID를 함께 저장한다.
+--   EVALUATION/RESUME/PORTFOLIO 타입에서는 해당 컬럼을 사용하지 않으므로 NULL 허용.
+ALTER TABLE ai_eval_jobs
+    ADD COLUMN competitor_application_id BIGINT NULL AFTER job_application_id,
+    ADD CONSTRAINT fk_ai_eval_jobs_competitor_application
+        FOREIGN KEY (competitor_application_id) REFERENCES job_applications (job_application_id);

--- a/src/main/resources/db/testdata/V2__test_seed_data.sql
+++ b/src/main/resources/db/testdata/V2__test_seed_data.sql
@@ -28,16 +28,19 @@ INSERT INTO job_masters (job_master_id, company_id, job_title, status, created_a
 VALUES (1, 1, '백엔드 개발자', 'OPEN', NOW(), NOW());
 
 -- ⑤ job_post 생성
+-- JobSourceType enum: ADMIN / USER / SCRAPED  ('MANUAL' 없음 → ADMIN)
+-- RegistrationStatus enum: DRAFT / CONFIRMED / CANCELED  ('REGISTERED' 없음 → CONFIRMED)
 INSERT INTO job_posts (job_post_id, job_master_id, ai_job_id, company_id, source_type, source_url, source_url_hash,
                        raw_company_name, raw_job_title, recruitment_status, registration_status, fingerprint_hash, created_at, updated_at)
-VALUES (1, 1, 1, 1, 'MANUAL', 'https://test.com/job/1', SHA2('https://test.com/job/1', 256),
-        '테스트주식회사', '백엔드 개발자', 'OPEN', 'REGISTERED', SHA2('test-fingerprint-1', 256), NOW(), NOW());
+VALUES (1, 1, 1, 1, 'ADMIN', 'https://test.com/job/1', SHA2('https://test.com/job/1', 256),
+        '테스트주식회사', '백엔드 개발자', 'OPEN', 'CONFIRMED', SHA2('test-fingerprint-1', 256), NOW(), NOW());
 
 -- ⑥ 지원 이력
+-- ApplicationStatus enum: SUBMITTED / ACTIVE / ARCHIVED  ('APPLIED' 없음 → SUBMITTED)
 INSERT INTO job_applications (job_application_id, user_id, job_master_id, status, created_at, updated_at)
 VALUES
-    (1, 1, 1, 'APPLIED', NOW(), NOW()),
-    (2, 2, 1, 'APPLIED', NOW(), NOW());
+    (1, 1, 1, 'SUBMITTED', NOW(), NOW()),
+    (2, 2, 1, 'SUBMITTED', NOW(), NOW());
 
 -- ⑦ AI 평가 결과 (cutline_score 통과용)
 INSERT INTO ai_applicant_evaluation (evaluation_id, job_application_id, overall_score,
@@ -49,7 +52,7 @@ VALUES
 -- ⑧ 채팅방 생성
 INSERT INTO chat_rooms (chat_room_id, job_master_id, created_by, room_name, max_participants,
                         room_goal, cutline_score, preferred_conditions, status, created_at, updated_at)
-VALUES (1, 1, 1, '백엔드 스터디방', 10, 'INTERVIEW', 80, NULL, 'OPEN', NOW(), NOW());
+VALUES (1, 1, 1, '백엔드 스터디방', 10, 'INTERVIEW', 80, NULL, 'ACTIVE', NOW(), NOW());
 
 -- ⑨ 채팅방 멤버
 INSERT INTO chat_room_members (chat_room_member_id, chat_room_id, user_id, job_application_id, role, joined_at)


### PR DESCRIPTION
## 개요

채팅방 멤버 간 AI 비교 분석 API의 동기 호출 구조를 RabbitMQ 비동기 처리로 전환합니다.
메시지 발행은 트랜잭션 커밋 확정 후 이벤트 기반으로 처리합니다.

---

## 배경 및 문제

기존 구현은 비교 분석 요청이 들어오면 AI 서버(`/ai/api/v1/applicant/compare`)에 HTTP 요청을 보내고 응답이 올 때까지 Tomcat 스레드를 그대로 점유하는 동기 구조였습니다.

k6 부하 테스트로 문제를 수치로 확인했습니다.

| 지표 | VU 10명 | VU 50명 |
|---|---|---|
| 평균 응답 시간 | 33,125 ms | 30,979 ms |
| p95 응답 시간 | 33,199 ms | 36,082 ms |
| timed-waiting threads (피크) | 20 | 60 |
| jvm_threads_live (피크) | 43 | 83 |

VU 50명 동시 요청 시 `timed-waiting` 상태 스레드가 9개(idle)에서 60개로 증가했으며, JVM 전체 라이브 스레드도 42개에서 83개로 2배가 됐습니다. 이는 AI 응답 대기 중 스레드가 블로킹되어 다른 API 응답까지 지연되는 구조적 문제입니다.

---

## 해결 방법

요청 처리와 AI 응답 수신을 분리하는 비동기 구조로 전환합니다.

메시지 브로커로 RabbitMQ를 선택한 이유는 요청 단위 작업 처리에 적합한 큐 기반 구조, ACK 기반의 명확한 처리 보장, AI 서버 장애 시 큐에 메시지를 보존하여 재처리가 가능하다는 점입니다. `@Async` + 스레드풀 방식도 검토했으나 서버 재시작 시 처리 중인 작업이 유실되고 재처리 로직을 직접 구현해야 하는 단점이 있어 제외했습니다.

**변경 전**
```
GET /comparison 요청
    → AI 서버 직접 호출 (WebClient.block())
    → 응답 대기 (스레드 점유)
    → DB 저장 → 200 반환
```

**변경 후**
```
POST /comparison 요청
    → AiEvalJob 생성 + 이벤트 발행
    → 트랜잭션 커밋 완료
    → @TransactionalEventListener(AFTER_COMMIT) 수신
    → RabbitMQ 메시지 발행
    → 즉시 202 반환 (스레드 해제)

AI 서버가 큐 소비 → 처리 완료 후 콜백
    → /api/internal/ai/callback
    → AiResultProcessingService → DB 저장

GET /comparison 요청
    → DB 결과 조회 전용 (결과 없으면 404)
```

---

## 변경 사항

### 1. `AiEvalJob` — `competitor_application_id` 필드 추가

COMPARISON 타입은 콜백 수신 시 `my_application_id`와 `competitor_application_id` 두 값이 모두 필요합니다. `eval_job_id`만으로는 경쟁자를 식별할 수 없으므로 `AiEvalJob` 생성 시 함께 저장합니다. EVALUATION/RESUME/PORTFOLIO 타입에서는 사용하지 않으므로 `nullable`입니다.

Flyway `V6` 마이그레이션으로 DB 컬럼을 반영합니다.

### 2. `AiRequestMessage` — `competitor` 필드 추가

AI 서버가 비교 분석을 수행하려면 경쟁자 ID가 메시지에 포함되어야 합니다. EVALUATION/RESUME/PORTFOLIO 요청 시에는 `null`로 전송되어 기존 동작에 영향을 주지 않습니다.

### 3. `ErrorCode` — `COMPARISON_RESULT_NOT_FOUND` 추가

비동기 전환 후 GET 엔드포인트는 결과 조회 전용이 됩니다. AI 처리가 아직 완료되지 않아 DB에 결과가 없는 경우 클라이언트가 폴링 시점을 인식할 수 있도록 전용 404 에러코드를 추가합니다.

### 4. `AiComparisonCreateEvent` — 신규 추가

COMPARISON 타입 전용 이벤트 클래스입니다. 기존 `AiAnalysisCreateEvent`와 분리한 이유는 두 가지입니다. COMPARISON은 `competitor` 정보가 추가로 필요하고, `AiEvalJob`이 이미 생성된 상태에서 이벤트를 발행하므로 `evalJobId`로 직접 조회하는 방식을 사용하기 때문입니다.

### 5. `ChatMemberComparisonService` — 비동기 전환 및 이벤트 기반 발행

기존 `compare()` 메서드를 두 메서드로 분리하고, RabbitMQ 직접 발행 대신 이벤트를 발행합니다.

- `requestComparison()`: 권한/멤버 검증 → `AiEvalJob` 생성 → `AiComparisonCreateEvent` 발행. 트랜잭션 내부에서 직접 MQ를 발행하면 DB 롤백 시에도 메시지가 발행되는 문제가 있으므로, 커밋 확정 후 발행을 위임합니다. `AiServiceClient`, `AiComparisonSaveHelper`, `RabbitTemplate` 의존성을 제거합니다.
- `getComparisonResult()`: DB 결과 조회 전용. 결과가 없으면 `COMPARISON_RESULT_NOT_FOUND(404)` 반환.

### 6. `AiEvaluationWorker` — COMPARISON 이벤트 핸들러 추가

`processComparisonAsync()`를 추가합니다. `AiComparisonCreateEvent`를 `AFTER_COMMIT` 시점에 수신하여 RabbitMQ에 메시지를 발행합니다. EVALUATION/RESUME/PORTFOLIO와 동일한 패턴으로 구조를 통일합니다.

### 7. `AiResultProcessingService` — `COMPARISON` 콜백 처리 추가

기존 `switch` 분기에 `COMPARISON` 케이스를 추가합니다. `AiEvalJob`에 저장된 `competitorApplication`을 활용해 `ai_applicant_comparison` 테이블에 저장하며, 이미 결과가 존재하는 경우 저장을 생략합니다. 알림 분기에도 `COMPARISON_COMPLETE` 케이스를 추가합니다.

### 8. `ChatRoomController` — 엔드포인트 분리

| 메서드 | 경로 | 역할 | 응답 |
|---|---|---|---|
| POST | `/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}/comparison` | 비교 분석 요청 | 202 Accepted |
| GET | `/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}/comparison` | 결과 조회 | 200 / 404 |

---

## 커밋 목록
```
feat: add competitor_application_id to AiEvalJob for COMPARISON type
feat: add competitor field to AiRequestMessage for COMPARISON type
feat: add COMPARISON_RESULT_NOT_FOUND error code
feat: convert ChatMemberComparisonService to async RabbitMQ processing
feat: handle COMPARISON type in AiResultProcessingService
feat: split comparison endpoint into POST (request) and GET (result)
refactor: publish comparison event after commit via TransactionalEventListener
```

---

## 트레이드오프

| 항목 | 내용 |
|---|---|
| 클라이언트 연동 변경 | 즉시 결과 반환 → 202 후 GET으로 폴링 필요. 프론트엔드 팀과 연동 방식 협의 필요 |
| 처리 시점 불확실성 | 큐 적체 시 처리 지연 가능. 운영 중 큐 모니터링 필요 |
| 판단 | 스레드 점유로 인한 전체 서버 영향이 더 큰 리스크. 감수 가능한 트레이드오프 |

---

## 테스트 확인 사항

- [ ] POST `/comparison` → 202 즉시 반환 확인
- [ ] RabbitMQ 관리 콘솔 `scuad.ai.queue.comparison` 메시지 적재 확인
- [ ] AI 콜백 수신 후 `ai_applicant_comparison` 테이블 저장 확인
- [ ] GET `/comparison` → 저장된 결과 정상 조회 확인
- [ ] GET `/comparison` AI 처리 전 조회 → 404 `COMPARISON_RESULT_NOT_FOUND` 반환 확인
- [ ] 기존 EVALUATION/RESUME/PORTFOLIO 비동기 처리 정상 동작 여부 확인 (회귀)