### PR TITLE
feat: 채용공고 상세 조회 Redis 캐싱 적용

### DIFF
--- a/src/main/java/com/thunder11/scuad/infra/redis/config/RedisCacheConfig.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/config/RedisCacheConfig.java
@@ -1,5 +1,12 @@
 package com.thunder11.scuad.infra.redis.config;
 
+import java.time.Duration;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,20 +17,33 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import java.time.Duration;
-
 @Configuration
 @EnableCaching
 public class RedisCacheConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        objectMapper.activateDefaultTyping(
+                objectMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
         RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
-                .disableCachingNullValues().entryTtl(Duration.ofDays(10))
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofDays(10))
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
 
         return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(configuration).build();
+                .cacheDefaults(configuration)
+                .build();
     }
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/dto/response/JobPostingDetailResponse.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/dto/response/JobPostingDetailResponse.java
@@ -4,14 +4,15 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.thunder11.scuad.jobposting.domain.JobMaster;
 import com.thunder11.scuad.jobposting.domain.JobPost;
 import com.thunder11.scuad.jobposting.domain.type.JobStatus;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class JobPostingDetailResponse {
 
         private Long jobMasterId;

--- a/src/main/java/com/thunder11/scuad/jobposting/service/JobPostingManagementService.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/JobPostingManagementService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 
 import lombok.RequiredArgsConstructor;
 
@@ -77,6 +78,7 @@ public class JobPostingManagementService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "jobDetail", key = "#jobMasterId", cacheManager = "cacheManager")
     public JobPostingDetailResponse getJobPostingDetail(Long jobMasterId) {
         JobMaster jobMaster = jobMasterRepository.findByIdWithDetails(jobMasterId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "채용공고 상세 정보를 찾을 수 없습니다."));
@@ -85,7 +87,10 @@ public class JobPostingManagementService {
     }
 
     @Transactional
-    @CacheEvict(value = "jobPostings", allEntries = true)
+    @Caching(evict = {
+            @CacheEvict(value = "jobPostings", allEntries = true),
+            @CacheEvict(value = "jobDetail", key = "#jobMasterId")
+    })
     public JobPostingConfirmResponse confirmJobPosting(Long jobMasterId, Long userId, RegistrationStatus status) {
         JobMaster jobMaster = jobMasterRepository.findById(jobMasterId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "채용공고를 찾을 수 없습니다."));
@@ -112,6 +117,10 @@ public class JobPostingManagementService {
     }
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "jobPostings", allEntries = true),
+            @CacheEvict(value = "jobDetail", key = "#jobMasterId")
+    })
     public void deleteJobPosting(Long jobMasterId, Long userId) {
         JobMaster jobMaster = jobMasterRepository.findById(jobMasterId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "삭제할 공고를 찾을 수 없습니다."));


### PR DESCRIPTION
- JobPostingDetailResponse에 NoArgsConstructor 추가하여 역직렬화 에러 해결
- RedisCacheConfig에 JavaTimeModule, Jdk8Module 등록하여 데이터 무결성 확보
- 공고 상세 서비스 레이어에 @Cacheable 적용으로 조회 성능 최적화