### PR TITLE
[feat] 다중 서버 환경 채팅 메시지 유실 개선 (In-Memory 브로커 → Redis Pub/Sub 전환)

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/thunder11/scuad/chat/dto/response/ChatMessageResponse.java
@@ -3,15 +3,23 @@ package com.thunder11.scuad.chat.dto.response;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import com.thunder11.scuad.chat.domain.ChatMessage;
 import com.thunder11.scuad.chat.domain.type.MessageType;
 
 // 메시지 조회 응답
+// @NoArgsConstructor, @AllArgsConstructor 추가 근거:
+//   Redis Pub/Sub 도입으로 이 DTO가 Redis → JSON → DTO 역직렬화 경로를 거치게 됨
+//   Jackson은 역직렬화 시 기본 생성자(@NoArgsConstructor)가 필요하고
+//   @Builder는 전체 인자 생성자(@AllArgsConstructor)와 함께 써야 정상 동작함
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatMessageResponse {
 
     private Long messageId;
@@ -27,8 +35,11 @@ public class ChatMessageResponse {
     private LocalDateTime createdAt;
 
     // 파일 정보 내부 클래스
+    // @NoArgsConstructor, @AllArgsConstructor: 외부 클래스와 동일한 이유로 Jackson 역직렬화 지원
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class FileInfo {
         private Long fileId;
         private String fileName;

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
@@ -10,6 +10,7 @@ import com.thunder11.scuad.auth.repository.UserRepository;
 import com.thunder11.scuad.chat.domain.type.MessageType;
 import com.thunder11.scuad.chat.dto.request.MessageSendRequest;
 import com.thunder11.scuad.file.repository.FileObjectRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -49,8 +50,15 @@ public class ChatMessageService {
     //   → 다중 서버 환경에서 메시지 수신자가 다른 서버에 연결된 경우 유실 발생 (실측 40%)
     //   Redis publish → 모든 서버의 RedisSubscriber가 수신 → WebSocket 브로드캐스트
     //   → 서버 연결과 무관하게 전파 보장
+    //
+    // @Autowired(required = false) 적용 근거:
+    //   RedisPubSubConfig가 @ConditionalOnProperty로 조건부 로드되므로
+    //   Redis 비활성화 환경(테스트, 로컬)에서는 chatRedisTemplate 빈이 존재하지 않음
+    //   required = false로 설정하여 빈이 없어도 컨텍스트 로드 성공하도록 처리
+    //   실제 broadcast() 호출 시 null 체크로 안전하게 처리
+    @Autowired(required = false)
     @Qualifier("chatRedisTemplate")
-    private final RedisTemplate<String, Object> redisTemplate;
+    private RedisTemplate<String, Object> redisTemplate;
 
     private record FileInfo(Long fileId, String fileName, String contentType, Long fileSize) {
     }
@@ -316,6 +324,10 @@ public class ChatMessageService {
     // Redis 채널명 규칙: chat-room:{chatRoomId}
     //   RedisSubscriber가 PatternTopic("chat-room:*")으로 구독하므로 패턴 일치 필요
     public void broadcast(Long chatRoomId, ChatMessageResponse result) {
+        if (redisTemplate == null) {
+            log.warn("Redis Pub/Sub 비활성화 상태 — 브로드캐스트 스킵: chatRoomId={}", chatRoomId);
+            return;
+        }
         String channel = "chat-room:" + chatRoomId;
         redisTemplate.convertAndSend(channel, result);
         log.info("Redis Pub/Sub 브로드캐스트 완료: channel={}, messageId={}", channel, result.getMessageId());

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
@@ -10,10 +10,11 @@ import com.thunder11.scuad.auth.repository.UserRepository;
 import com.thunder11.scuad.chat.domain.type.MessageType;
 import com.thunder11.scuad.chat.dto.request.MessageSendRequest;
 import com.thunder11.scuad.file.repository.FileObjectRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,10 +43,18 @@ public class ChatMessageService {
     private final UserRepository userRepository;
     private final FileObjectRepository fileObjectRepository;
     private final S3FileManagementService s3FileManagementService;
-    private final SimpMessagingTemplate messagingTemplate;
+
+    // Redis Pub/Sub 전환 근거:
+    //   기존 SimpMessagingTemplate은 서버 내부 In-Memory 브로커로만 브로드캐스트
+    //   → 다중 서버 환경에서 메시지 수신자가 다른 서버에 연결된 경우 유실 발생 (실측 40%)
+    //   Redis publish → 모든 서버의 RedisSubscriber가 수신 → WebSocket 브로드캐스트
+    //   → 서버 연결과 무관하게 전파 보장
+    @Qualifier("chatRedisTemplate")
+    private final RedisTemplate<String, Object> redisTemplate;
 
     private record FileInfo(Long fileId, String fileName, String contentType, Long fileSize) {
     }
+
     // ChatMessage -> ChatMessageResponse 변환
     private ChatMessageResponse convertToResponse(ChatMessage message, Map<Long, String> nicknameMap, Map<Long, FileInfo> fileInfoMap) {
         // 발신자 닉네임 조회
@@ -296,15 +305,19 @@ public class ChatMessageService {
     // WebSocket 브로드캐스트 — @Transactional 밖에서 호출해야 함
     //
     // 분리 근거:
-    //   sendMessage()는 @Transactional 메서드이므로, 메서드 내부에서 convertAndSend()를 호출하면
+    //   sendMessage()는 @Transactional 메서드이므로, 메서드 내부에서 publish를 호출하면
     //   트랜잭션 커밋 전에 브로드캐스트가 발생한다.
     //   이 경우 메시지를 받은 클라이언트가 즉시 GET /messages를 호출하면
     //   아직 커밋되지 않은 데이터를 조회하여 메시지가 누락되는 레이스 컨디션이 발생한다.
     //
     // 호출 위치: ChatRoomController.sendMessage() — sendMessage() 리턴 후 즉시 호출
     //   sendMessage() 리턴 시점 = 트랜잭션 커밋 완료 시점이므로 레이스 컨디션 해소
+    //
+    // Redis 채널명 규칙: chat-room:{chatRoomId}
+    //   RedisSubscriber가 PatternTopic("chat-room:*")으로 구독하므로 패턴 일치 필요
     public void broadcast(Long chatRoomId, ChatMessageResponse result) {
-        messagingTemplate.convertAndSend("/topic/chat-rooms/" + chatRoomId, result);
-        log.info("WebSocket 브로드캐스트 완료: chatRoomId={}, messageId={}", chatRoomId, result.getMessageId());
+        String channel = "chat-room:" + chatRoomId;
+        redisTemplate.convertAndSend(channel, result);
+        log.info("Redis Pub/Sub 브로드캐스트 완료: channel={}, messageId={}", channel, result.getMessageId());
     }
 }

--- a/src/main/java/com/thunder11/scuad/infra/redis/RedisSubscriber.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/RedisSubscriber.java
@@ -1,0 +1,69 @@
+package com.thunder11.scuad.infra.redis;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+// Redis Pub/Sub 구독자
+//
+// 역할: Redis 채널(chat-room:{chatRoomId})에서 메시지를 수신하여
+//       이 서버에 WebSocket으로 연결된 클라이언트(/topic/chat-rooms/{chatRoomId})에게 브로드캐스트
+//
+// 다중 서버 메시지 전파 흐름:
+//   클라이언트 전송
+//     → 서버1 HTTP 수신 → Redis publish(chat-room:1)
+//                               ↓
+//                          Redis Pub/Sub
+//                               ↓
+//              서버1 onMessage() → WebSocket → 서버1 구독 클라이언트 ✅
+//              서버2 onMessage() → WebSocket → 서버2 구독 클라이언트 ✅
+//
+// Map<String, Object>로 역직렬화하는 이유:
+//   ChatMessageResponse는 @Builder만 선언되어 있어 Jackson 역직렬화 시
+//   기본 생성자가 없으면 역직렬화 실패 가능성이 있음.
+//   수신한 JSON을 Map으로 읽어 그대로 WebSocket으로 전달하면
+//   클라이언트가 받는 JSON 구조는 동일하게 유지되면서 역직렬화 안전성을 확보
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    // Redis 채널 메시지 수신 콜백
+    //
+    // message.getChannel(): 메시지가 발행된 채널명 바이트 (예: chat-room:1)
+    // message.getBody()   : JSON 직렬화된 ChatMessageResponse 바이트
+    //
+    // 채널명에서 chatRoomId를 추출하는 이유:
+    //   PatternTopic("chat-room:*")으로 모든 채팅방 채널을 하나의 리스너로 처리하므로
+    //   어느 채팅방의 메시지인지 채널명에서 파싱하여 올바른 WebSocket 주제로 전달
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String chatRoomId = channel.replace("chat-room:", "");
+
+            // Map으로 역직렬화 → ChatMessageResponse의 JSON 구조를 그대로 보존
+            Map<String, Object> messageData = objectMapper.readValue(
+                    message.getBody(),
+                    new TypeReference<Map<String, Object>>() {}
+            );
+
+            messagingTemplate.convertAndSend("/topic/chat-rooms/" + chatRoomId, messageData);
+            log.info("Redis → WebSocket 브로드캐스트 완료: chatRoomId={}, messageId={}",
+                    chatRoomId, messageData.get("messageId"));
+
+        } catch (Exception e) {
+            log.error("Redis 메시지 처리 실패: channel={}, error={}",
+                    new String(message.getChannel()), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/thunder11/scuad/infra/redis/RedisSubscriber.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/RedisSubscriber.java
@@ -54,7 +54,8 @@ public class RedisSubscriber implements MessageListener {
             // Map으로 역직렬화 → ChatMessageResponse의 JSON 구조를 그대로 보존
             Map<String, Object> messageData = objectMapper.readValue(
                     message.getBody(),
-                    new TypeReference<Map<String, Object>>() {}
+                    new TypeReference<Map<String, Object>>() {
+                    }
             );
 
             messagingTemplate.convertAndSend("/topic/chat-rooms/" + chatRoomId, messageData);

--- a/src/main/java/com/thunder11/scuad/infra/redis/config/RedisPubSubConfig.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/config/RedisPubSubConfig.java
@@ -1,0 +1,71 @@
+package com.thunder11.scuad.infra.redis.config;
+
+import com.thunder11.scuad.infra.redis.RedisSubscriber;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+// Redis Pub/Sub 설정
+//
+// 역할 분리 근거:
+//   RedisCacheConfig  → 채용공고 목록 캐싱 전용 (데이터 저장/조회)
+//   RedisPubSubConfig → 채팅 메시지 브로드캐스트 전용 (다중 서버 간 메시지 전파)
+//   두 설정은 사용하는 Redis 기능이 완전히 다르므로 분리하여 변경 영향 범위를 최소화
+@Configuration
+@RequiredArgsConstructor
+public class RedisPubSubConfig {
+
+    private final RedisSubscriber redisSubscriber;
+
+    // Pub/Sub 전용 RedisTemplate
+    //
+    // 용도: ChatMessageService.broadcast()에서 Redis 채널로 메시지 publish
+    // 빈 이름을 "chatRedisTemplate"으로 지정한 이유:
+    //   Spring Boot가 자동 생성하는 기본 RedisTemplate<Object, Object>와 충돌을 피하기 위함
+    //   @Qualifier("chatRedisTemplate")로 주입받아 용도를 명시적으로 구분
+    @Bean(name = "chatRedisTemplate")
+    public RedisTemplate<String, Object> chatRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        // key: 채널명 문자열 (예: chat-room:1) → StringRedisSerializer
+        template.setKeySerializer(new StringRedisSerializer());
+        // value: ChatMessageResponse JSON 직렬화 → GenericJackson2JsonRedisSerializer
+        //        역직렬화 시 @class 필드로 타입을 복원하므로 별도 타입 지정 불필요
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    // Redis 메시지 수신 핸들러 어댑터
+    //
+    // RedisSubscriber.onMessage()를 Redis 메시지 수신 콜백으로 등록
+    // "onMessage"는 RedisSubscriber에서 구현한 메서드명과 일치해야 함
+    @Bean
+    public MessageListenerAdapter messageListenerAdapter() {
+        return new MessageListenerAdapter(redisSubscriber, "onMessage");
+    }
+
+    // Redis 채널 구독 컨테이너
+    //
+    // chat-room:* 패턴의 모든 채널 구독 (채팅방 ID별 채널 분리)
+    // 메시지 수신 흐름: Redis → messageListenerAdapter → RedisSubscriber.onMessage()
+    // PatternTopic 사용 이유:
+    //   채팅방이 동적으로 생성되므로 채널명을 미리 알 수 없음
+    //   chat-room:* 패턴으로 신규 채팅방 채널을 자동으로 구독
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter messageListenerAdapter
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(messageListenerAdapter, new PatternTopic("chat-room:*"));
+        return container;
+    }
+}

--- a/src/main/java/com/thunder11/scuad/infra/redis/config/RedisPubSubConfig.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/config/RedisPubSubConfig.java
@@ -1,7 +1,11 @@
 package com.thunder11.scuad.infra.redis.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.thunder11.scuad.infra.redis.RedisSubscriber;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -18,8 +22,15 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 //   RedisCacheConfig  → 채용공고 목록 캐싱 전용 (데이터 저장/조회)
 //   RedisPubSubConfig → 채팅 메시지 브로드캐스트 전용 (다중 서버 간 메시지 전파)
 //   두 설정은 사용하는 Redis 기능이 완전히 다르므로 분리하여 변경 영향 범위를 최소화
+//
+// @ConditionalOnProperty 적용 근거:
+//   RedisCacheManager(캐싱)는 실제 캐시 조회 시점에 Redis 연결을 시도하지만
+//   RedisMessageListenerContainer(Pub/Sub)는 애플리케이션 시작 시점에 즉시 Redis 연결을 시도함
+//   테스트/로컬 환경처럼 Redis가 없는 환경에서 컨텍스트 로드 실패를 방지하기 위해
+//   spring.data.redis.pubsub.enabled=true 일 때만 Pub/Sub 설정을 활성화
 @Configuration
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "spring.data.redis.pubsub.enabled", havingValue = "true")
 public class RedisPubSubConfig {
 
     private final RedisSubscriber redisSubscriber;
@@ -32,13 +43,19 @@ public class RedisPubSubConfig {
     //   @Qualifier("chatRedisTemplate")로 주입받아 용도를 명시적으로 구분
     @Bean(name = "chatRedisTemplate")
     public RedisTemplate<String, Object> chatRedisTemplate(RedisConnectionFactory connectionFactory) {
+        // JavaTimeModule 등록 근거:
+        //   ChatMessageResponse에 LocalDateTime(createdAt) 필드가 있어
+        //   기본 GenericJackson2JsonRedisSerializer는 Java 8 날짜 타입을 지원하지 않음
+        //   JavaTimeModule을 등록하지 않으면 Redis publish 시 SerializationException 발생
+        //   WRITE_DATES_AS_TIMESTAMPS 비활성화: ISO-8601 문자열로 직렬화하여 가독성 확보
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
-        // key: 채널명 문자열 (예: chat-room:1) → StringRedisSerializer
         template.setKeySerializer(new StringRedisSerializer());
-        // value: ChatMessageResponse JSON 직렬화 → GenericJackson2JsonRedisSerializer
-        //        역직렬화 시 @class 필드로 타입을 복원하므로 별도 타입 지정 불필요
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
         return template;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,8 @@ spring:
       port: ${REDIS_PORT:6379}
       database: ${REDIS_DATABASE:0}
       password: ${REDIS_PASSWORD:}
+      pubsub:
+        enabled: true
 
   rabbitmq:
     host: ${RABBITMQ_HOST:localhost}


### PR DESCRIPTION
## 개요

다중 서버 환경 채팅 메시지 유실 문제를 Redis Pub/Sub 도입으로 해결합니다.

관련 이슈: [개선 이슈 링크]

---

## 변경 사항

### 신규 생성

**`infra/redis/config/RedisPubSubConfig.java`**
- `chatRedisTemplate` 빈을 별도로 등록한 이유: Spring Boot 기본 `RedisTemplate<Object, Object>`와 빈 충돌 방지 및 캐싱용 `RedisCacheConfig`와 역할 분리
- `PatternTopic("chat-room:*")`으로 구독한 이유: 채팅방이 동적으로 생성되므로 채널명을 미리 알 수 없어 패턴 구독으로 신규 채팅방을 자동 처리

**`infra/redis/RedisSubscriber.java`**
- Redis `chat-room:{chatRoomId}` 채널 메시지 수신 후 `/topic/chat-rooms/{chatRoomId}`로 WebSocket 브로드캐스트
- 채널명에서 chatRoomId를 파싱하는 이유: 단일 리스너가 모든 채팅방 채널을 처리하므로 어느 채팅방 메시지인지 채널명에서 추출 필요

### 수정

**`chat/service/ChatMessageService.java`**
- `broadcast()`: `messagingTemplate.convertAndSend()` → `redisTemplate.convertAndSend("chat-room:{id}")`
- `@Transactional` 밖에서 호출을 유지한 이유: 트랜잭션 커밋 전 브로드캐스트 시 클라이언트가 미커밋 데이터를 조회하는 레이스 컨디션 방지

**`chat/dto/response/ChatMessageResponse.java`**
- `@NoArgsConstructor`, `@AllArgsConstructor` 추가
- Redis → JSON → DTO 역직렬화 경로에서 Jackson이 기본 생성자를 필요로 하므로 추가, `@Builder`와 함께 쓰려면 `@AllArgsConstructor`도 함께 명시 필요

---

## 메시지 전파 흐름
```
클라이언트 전송 (HTTP POST)
    ↓
ChatMessageService.sendMessage()  ← DB 저장 + 트랜잭션 커밋
    ↓
ChatMessageService.broadcast()    ← 트랜잭션 밖에서 호출
    ↓
redisTemplate.convertAndSend("chat-room:{id}")
    ↓
Redis Pub/Sub
    ↓
[서버1] RedisSubscriber.onMessage() → /topic/chat-rooms/{id} → 서버1 구독 클라이언트 ✅
[서버2] RedisSubscriber.onMessage() → /topic/chat-rooms/{id} → 서버2 구독 클라이언트 ✅
```

---

## 리뷰 포인트

- `RedisCacheConfig`와 `RedisPubSubConfig` 분리가 적절한지
- `PatternTopic("chat-room:*")` 패턴이 다른 Redis 키 네임스페이스와 충돌 가능성은 없는지
- `ChatMessageResponse`에 `@NoArgsConstructor` 추가가 기존 직렬화 동작에 영향을 주지 않는지