### PR TITLE
fix : 카카오 OAuth 동시 가입 시 중복 계정 생성 Race Condition 수정

### DIFF
--- a/src/main/java/com/thunder11/scuad/auth/domain/UserOAuthAccount.java
+++ b/src/main/java/com/thunder11/scuad/auth/domain/UserOAuthAccount.java
@@ -10,7 +10,13 @@ import com.thunder11.scuad.common.entity.BaseTimeEntity;
 // 사용자 OAuth 계정 연동 정보
 // 한 사용자가 여러 OAuth 제공자 계정 연동 가능 (지금은 kakao)
 @Entity
-@Table(name = "user_oauth_accounts")
+@Table(
+        name = "user_oauth_accounts",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_oauth_accounts_provider_user",
+                columnNames = {"provider", "provider_user_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserOAuthAccount extends BaseTimeEntity {

--- a/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
+++ b/src/main/java/com/thunder11/scuad/auth/service/AuthService.java
@@ -82,9 +82,25 @@ public class AuthService {
         log.info("카카오 사용자 정보 조회 완료: kakaoUserId={}", kakaoUserId);
 
         // 3. 기존 사용자 조회 또는 신규 회원가입
-        UserOAuthAccount oAuthAccount = oAuthAccountRepository
-                .findByProviderAndProviderUserId(OAuthProvider.KAKAO, kakaoUserId)
-                .orElseGet(() -> registerNewUser(userInfo));
+        // 동시 가입 race condition 방어:
+        //   동일한 kakaoUserId로 동시에 2개 이상의 콜백이 들어올 경우
+        //   findBy → orElseGet → registerNewUser → tryCreateUser → saveAndFlush 흐름에서
+        //   user_oauth_accounts UK 위반(uk_provider_user_id)이 발생할 수 있음.
+        //   닉네임 충돌은 registerNewUser() 내부 루프에서 처리되고
+        //   10회 초과 시 ApiException(INTERNAL_ERROR)을 던지므로
+        //   여기까지 전파되는 DataIntegrityViolationException은 OAuth UK 위반으로 간주하여
+        //   이미 저장된 계정을 재조회해 정상 로그인 흐름으로 복구한다.
+        UserOAuthAccount oAuthAccount;
+        try {
+            oAuthAccount = oAuthAccountRepository
+                    .findByProviderAndProviderUserId(OAuthProvider.KAKAO, kakaoUserId)
+                    .orElseGet(() -> registerNewUser(userInfo));
+        } catch (DataIntegrityViolationException e) {
+            log.warn("동시 가입 충돌 감지, 기존 계정 재조회: kakaoUserId={}", kakaoUserId);
+            oAuthAccount = oAuthAccountRepository
+                    .findByProviderAndProviderUserId(OAuthProvider.KAKAO, kakaoUserId)
+                    .orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_ERROR));
+        }
 
         User user = oAuthAccount.getUser();
 

--- a/src/main/java/com/thunder11/scuad/auth/service/UserRegistrationHelper.java
+++ b/src/main/java/com/thunder11/scuad/auth/service/UserRegistrationHelper.java
@@ -54,7 +54,7 @@ public class UserRegistrationHelper {
                 .connectedAt(LocalDateTime.now())
                 .build();
 
-        UserOAuthAccount savedOAuthAccount = oAuthAccountRepository.save(oAuthAccount);
+        UserOAuthAccount savedOAuthAccount = oAuthAccountRepository.saveAndFlush(oAuthAccount);
         log.info("OAuth 계정 연동 완료: provider={}, providerUserId={}", provider, providerUserId);
 
         return savedOAuthAccount;


### PR DESCRIPTION
## 개요
카카오 OAuth 동시 가입 시 중복 계정이 생성되는 Race Condition을 수정합니다.

## 문제
동일한 카카오 계정으로 동시에 2개 이상의 콜백 요청이 들어올 경우,
여러 스레드가 동시에 "계정 없음"을 확인하고 모두 `registerNewUser()`를 실행합니다.

`oAuthAccountRepository.save()`가 flush 없이 호출되어 UK 위반 예외가
REQUIRES_NEW 트랜잭션 커밋 시점에 늦게 발생하고,
이 예외가 `registerNewUser()`의 닉네임 충돌 catch로 오인되어
최대 10회 재시도 후 `INTERNAL_ERROR → 500 응답`이 반환되는 문제가 있었습니다.

## 변경 사항
- `UserOAuthAccount`: `@Table`에 `uniqueConstraints` 추가 (`uk_oauth_accounts_provider_user`)
  - `V1__init.sql`에 이미 존재하는 UK를 엔티티에도 명시하여 DB 스키마와 명세를 일치
  - H2 테스트 환경에서 UK 없이 스키마가 생성되던 문제 해결
- `UserRegistrationHelper`: `oAuthAccountRepository.save()` → `saveAndFlush()` 변경
  - OAuth UK 위반 예외를 커밋 시점이 아닌 `saveAndFlush` 호출 지점에서 즉시 발생시켜
    닉네임 충돌 예외와 명확히 분리
- `AuthService`: `processKakaoCallback()`에 `DataIntegrityViolationException` catch 추가
  - OAuth UK 위반 발생 시 기존 계정을 재조회하여 정상 로그인 흐름으로 복구

## 테스트
JUnit 동시성 테스트 (`OAuthConcurrencyTest`) — 스레드 5개 동시 실행

| 항목 | 개선 전 | 개선 후 |
|---|---|---|
| 저장된 OAuth 계정 수 | 5 (중복 row) | **1** |
| processKakaoCallback 최종 결과 | 500 응답 | **5개 모두 정상 로그인** |
| race condition 여부 | 발생 | **해결** |

## 관련 문서
- `[개선] 카카오 OAuth 동시 가입 시 중복 계정 생성 (Race Condition)`
- 유사 이슈: `[개선] 동시 카카오 로그인 시 닉네임 중복 저장 (Race Condition)`