### PR TITLE
feat : 채팅방 멤버 단건 조회 추가

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -251,6 +251,33 @@ public class ChatRoomController {
         );
     }
 
+    // 채팅방 멤버 단건 조회
+    // 추가 근거: 프론트에서 특정 멤버 정보를 개별 조회해야 하는 케이스(예: 프로필 진입)가 존재하고,
+    //           기존 목록 API만으로는 단건 갱신이 불필요하게 무거움.
+    //           500 오류 재현 원인이 이 핸들러의 미구현이었으므로 신규 추가.
+    @GetMapping("/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}")
+    public ApiResponse<ChatRoomMemberResponse> getChatRoomMember(
+            @PathVariable Long chatRoomId,
+            @PathVariable Long chatRoomMemberId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        log.info("GET /api/v1/chat-rooms/{}/members/{} - userId={}",
+                chatRoomId, chatRoomMemberId, userPrincipal.getUserId());
+
+        ChatRoomMemberResponse response = chatRoomService.getChatRoomMember(
+                chatRoomId,
+                userPrincipal.getUserId(),
+                chatRoomMemberId
+        );
+
+        return ApiResponse.of(
+                HttpStatus.OK.value(),
+                "SUCCESS",
+                "멤버 단건 조회 성공",
+                response
+        );
+    }
+
     // 채팅방 퇴장
     @DeleteMapping("/chat-rooms/{chatRoomId}/members/me")
     public ApiResponse<Void> leaveChatRoom(

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -741,6 +741,67 @@ public class ChatRoomService {
 
         return ChatRoomMemberListResponse.of(memberResponses);
     }
+    // 채팅방 멤버 단건 조회
+    // 추가 근거: GET /api/v1/chat-rooms/{chatRoomId}/members/{chatRoomMemberId} 핸들러 신규 구현에 따라
+    //           목록 조회(getChatRoomMembers)와 동일한 권한 검증·presigned URL 생성 패턴을 단건에 적용
+    //           chatRoomId 교차 검증을 포함해 다른 방 멤버를 조회하는 부정 접근 방어
+    public ChatRoomMemberResponse getChatRoomMember(Long chatRoomId, Long requestUserId, Long chatRoomMemberId) {
+        log.info("채팅방 멤버 단건 조회 시작: chatRoomId={}, requestUserId={}, chatRoomMemberId={}",
+                chatRoomId, requestUserId, chatRoomMemberId);
+
+        // 1. 채팅방 존재 확인
+        chatRoomRepository.findByIdNotDeleted(chatRoomId)
+                .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 2. 요청자가 채팅방 멤버인지 확인 (권한 검증 — getChatRoomMembers와 동일한 패턴)
+        chatRoomMemberRepository.findByChatRoomIdAndUserIdAndKickedAtIsNull(chatRoomId, requestUserId)
+                .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_ACCESS_DENIED));
+
+        // 3. 대상 멤버 조회 (강퇴되지 않은 활성 멤버만)
+        ChatRoomMember member = chatRoomMemberRepository
+                .findByChatRoomMemberIdAndKickedAtIsNull(chatRoomMemberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.CHAT_MEMBER_NOT_FOUND));
+
+        // 4. chatRoomId 교차 검증: 해당 멤버가 요청 chatRoom 소속인지 확인
+        //    의도: /chat-rooms/1/members/2 호출 시 memberId=2가 chatRoom=99 소속이어도 조회 가능한
+        //          보안 취약점을 차단
+        if (!member.getChatRoomId().equals(chatRoomId)) {
+            log.warn("chatRoomId 불일치: 요청 chatRoomId={}, 실제 chatRoomId={}, chatRoomMemberId={}",
+                    chatRoomId, member.getChatRoomId(), chatRoomMemberId);
+            throw new ApiException(ErrorCode.CHAT_MEMBER_NOT_FOUND);
+        }
+
+        // 5. 닉네임 + profileImageFileId 조회 (목록 조회와 동일 방식)
+        List<Long> userIds = List.of(member.getUserId());
+        Map<Long, String> nicknameMap = new java.util.HashMap<>();
+        Map<Long, Long> profileImageFileIdMap = new java.util.HashMap<>();
+
+        userRepository.findNicknameAndProfileImageByUserIds(userIds)
+                .forEach(row -> {
+                    Long uid = (Long) row[0];
+                    nicknameMap.put(uid, (String) row[1]);
+                    profileImageFileIdMap.put(uid, (Long) row[2]);
+                });
+
+        // 6. presigned URL 생성 (profileImageFileId가 있는 경우에만)
+        //    만료 10분: 멤버 단건 조회도 목록과 동일한 만료 시간 정책 적용
+        String profileImageUrl = null;
+        Long fileId = profileImageFileIdMap.get(member.getUserId());
+        if (fileId != null) {
+            try {
+                profileImageUrl = s3FileManagementService.generatePresignedUrl(fileId, Duration.ofMinutes(10));
+            } catch (Exception e) {
+                log.warn("프로필 이미지 URL 생성 실패: userId={}, fileId={}", member.getUserId(), fileId);
+            }
+        }
+
+        String nickname = nicknameMap.getOrDefault(member.getUserId(), "알 수 없음");
+        ChatRoomMemberResponse response = ChatRoomMemberResponse.of(member, nickname, profileImageUrl);
+
+        log.info("채팅방 멤버 단건 조회 완료: chatRoomId={}, chatRoomMemberId={}", chatRoomId, chatRoomMemberId);
+        return response;
+    }
+
     // 내가 참여 중인 채팅방 목록 조회
     // 사용자는 본인이 참여 중인 채팅방 리스트를 확인할 수 있어야 함
     // 최신 참여 순으로 정렬하여 활동성 높은 채팅방을 우선 표시


### PR DESCRIPTION
## 개요

채팅방 멤버 단건 조회 API 누락으로 인해 발생한 500 Internal Server Error 수정

---

## 문제 상황

**재현 경로**
```
GET /api/v1/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}
```

**증상**
- 프론트엔드에서 해당 엔드포인트 호출 시 `500 Internal Server Error` 반환
- 요청 파라미터 정상, 프론트엔드 문제 아님 확인

**원인**
`ChatRoomController`에 해당 엔드포인트 핸들러가 **미구현** 상태였음.  
Spring MVC가 매핑을 찾지 못해 `NoHandlerFoundException` → 500으로 반환됨.

---

## ✅ 변경 사항

### `ChatRoomController.java`
- `GET /api/v1/chat-rooms/{chatRoomId}/members/{chatRoomMemberId}` 핸들러 추가

### `ChatRoomService.java`
- `getChatRoomMember(chatRoomId, requestUserId, chatRoomMemberId)` 메서드 추가

---

## 🔍 구현 세부 내용

### 서비스 로직 처리 순서

| 단계 | 내용 | 근거 |
|------|------|------|
| 1 | 채팅방 존재 확인 | 잘못된 `chatRoomId` → 404 |
| 2 | 요청자 멤버 권한 확인 | 비멤버 접근 → 403 (기존 목록 API와 동일 패턴) |
| 3 | 대상 멤버 조회 | 기존 `findByChatRoomMemberIdAndKickedAtIsNull()` 재사용 |
| 4 | `chatRoomId` 교차 검증 | 다른 채팅방 멤버 조회 가능한 보안 취약점 차단 |
| 5 | 닉네임 + presigned URL 생성 | `getChatRoomMembers()`와 동일 방식, 코드 일관성 유지 |

### 응답 형식
기존 `ChatRoomMemberResponse` DTO 그대로 사용 (신규 DTO 추가 없음)
```json
{
  "status": 200,
  "code": "SUCCESS",
  "message": "멤버 단건 조회 성공",
  "data": {
    "chatRoomMemberId": 2,
    "userId": 10,
    "nickname": "홍길동",
    "profileImageUrl": "https://...",
    "role": "MEMBER",
    "joinedAt": "2025-03-01T12:00:00"
  }
}
```

---

## 보안 고려사항

`chatRoomId` 교차 검증 추가:  
`GET /chat-rooms/1/members/99` 요청 시, `memberId=99`가 실제로 `chatRoom=99` 소속이더라도 접근할 수 없도록 방어 처리

---

## 📂 변경 파일

- `src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java`
- `src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java`