### PR TITLE
feat: 지원 내역 리스트 조회 N+1 문제 해결 및 데이터 로딩 최적화

### DIFF
--- a/src/main/java/com/thunder11/scuad/jobposting/repository/AiApplicationEvaluationRepository.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/repository/AiApplicationEvaluationRepository.java
@@ -1,6 +1,7 @@
 package com.thunder11.scuad.jobposting.repository;
 
 import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ import com.thunder11.scuad.jobposting.domain.AiApplicantEvaluation;
 
 public interface AiApplicationEvaluationRepository extends JpaRepository<AiApplicantEvaluation, Long> {
     Optional<AiApplicantEvaluation> findByJobApplicationId(Long jobApplicationId);
+    List<AiApplicantEvaluation> findAllByJobApplicationIdIn(List<Long> jobApplicationIds);
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/repository/AiPortfolioAnalysisRepository.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/repository/AiPortfolioAnalysisRepository.java
@@ -1,6 +1,7 @@
 package com.thunder11.scuad.jobposting.repository;
 
 import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ import com.thunder11.scuad.jobposting.domain.AiPortfolioAnalysis;
 
 public interface AiPortfolioAnalysisRepository extends JpaRepository<AiPortfolioAnalysis, Long> {
     Optional<AiPortfolioAnalysis> findByJobApplicationId(Long applicationId);
+    List<AiPortfolioAnalysis> findAllByJobApplicationIdIn(List<Long> jobApplicationIds);
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/repository/AiResumeAnalysisRepository.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/repository/AiResumeAnalysisRepository.java
@@ -1,6 +1,7 @@
 package com.thunder11.scuad.jobposting.repository;
 
 import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ import com.thunder11.scuad.jobposting.domain.AiResumeAnalysis;
 
 public interface AiResumeAnalysisRepository extends JpaRepository<AiResumeAnalysis, Long> {
     Optional<AiResumeAnalysis> findByJobApplicationId(long applicationId);
+    List<AiResumeAnalysis> findAllByJobApplicationIdIn(List<Long> jobApplicationIds);
 }

--- a/src/main/java/com/thunder11/scuad/jobposting/repository/JobApplicationRepository.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/repository/JobApplicationRepository.java
@@ -31,9 +31,10 @@ public interface JobApplicationRepository extends JpaRepository<JobApplication, 
         @Query("SELECT ja FROM JobApplication ja LEFT JOIN FETCH ja.applicationDocuments WHERE ja.id = :id")
         Optional<JobApplication> findByIdWithDocuments(@Param("id") Long id);
 
-        @Query("SELECT ja FROM JobApplication ja " +
+        @Query("SELECT DISTINCT ja FROM JobApplication ja " +
                         "JOIN FETCH ja.jobMaster jm " +
                         "JOIN FETCH jm.company c " +
+                        "LEFT JOIN FETCH ja.applicationDocuments " +
                         "WHERE ja.user.userId = :userId " +
                         "AND (:keyword IS NULL OR c.name LIKE %:keyword% OR jm.jobTitle LIKE %:keyword%) " +
                         "ORDER BY ja.createdAt DESC")

--- a/src/main/java/com/thunder11/scuad/jobposting/service/JobApplicationService.java
+++ b/src/main/java/com/thunder11/scuad/jobposting/service/JobApplicationService.java
@@ -18,6 +18,7 @@ import com.thunder11.scuad.common.exception.ApiException;
 import com.thunder11.scuad.common.exception.ErrorCode;
 import com.thunder11.scuad.file.domain.FileObject;
 import com.thunder11.scuad.file.service.FileStorageService;
+import com.thunder11.scuad.jobposting.domain.AiApplicantEvaluation;
 import com.thunder11.scuad.jobposting.domain.ApplicationDocument;
 import com.thunder11.scuad.jobposting.domain.JobApplication;
 import com.thunder11.scuad.jobposting.domain.JobMaster;
@@ -82,7 +83,6 @@ public class JobApplicationService {
             analysisService.createEvaluationJob(application.getId(), userId, "PORTFOLIO");
         }
 
-
         return application.getId();
     }
 
@@ -103,9 +103,10 @@ public class JobApplicationService {
         }
         ApplicationDocumentType type = ApplicationDocumentType.valueOf(docType.toUpperCase());
 
-        Optional<ApplicationDocument> existingDoc = applicationDocumentRepository.findByJobApplication_IdAndDocType(applicationId, type);
+        Optional<ApplicationDocument> existingDoc = applicationDocumentRepository
+                .findByJobApplication_IdAndDocType(applicationId, type);
 
-        if(existingDoc.isPresent()) {
+        if (existingDoc.isPresent()) {
             return updateDocument(existingDoc.get(), file, docType);
         } else {
             return saveDocument(jobApplication, docType, file);
@@ -114,22 +115,37 @@ public class JobApplicationService {
 
     @Transactional(readOnly = true)
     public List<MyApplicationResponse> getMyApplications(Long userId, String keyword) {
-        return jobApplicationRepository.findMyApplication(userId, keyword)
+        List<JobApplication> applications = jobApplicationRepository.findMyApplication(userId, keyword);
+        if (applications.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> applicationIds = applications.stream().map(JobApplication::getId).toList();
+
+        Map<Long, Integer> scoreMap = aiApplicationEvaluationRepository.findAllByJobApplicationIdIn(applicationIds)
                 .stream()
+                .collect(Collectors.toMap(e -> e.getJobApplication().getId(), AiApplicantEvaluation::getOverallScore,
+                        (a, b) -> a));
+
+        List<Long> resumeAnalyzedIds = aiResumeAnalysisRepository.findAllByJobApplicationIdIn(applicationIds)
+                .stream().map(e -> e.getJobApplication().getId()).toList();
+        List<Long> portfolioAnalyzedIds = aiPortfolioAnalysisRepository.findAllByJobApplicationIdIn(applicationIds)
+                .stream().map(e -> e.getJobApplication().getId()).toList();
+
+        return applications.stream()
                 .map(ja -> {
-                    Integer score = aiApplicationEvaluationRepository.findByJobApplicationId(ja.getId())
-                            .map(eval -> eval.getOverallScore())
-                            .orElse(null);
-                    boolean resumeAnalyzed = aiResumeAnalysisRepository.findByJobApplicationId(ja.getId()).isPresent();
-                    boolean portfolioAnalyzed = aiPortfolioAnalysisRepository.findByJobApplicationId(ja.getId()).isPresent();
-                    
+                    Integer score = scoreMap.get(ja.getId());
+                    boolean resumeAnalyzed = resumeAnalyzedIds.contains(ja.getId());
+                    boolean portfolioAnalyzed = portfolioAnalyzedIds.contains(ja.getId());
+
                     boolean resumeRegistered = ja.getApplicationDocuments().stream()
                             .anyMatch(d -> d.getDocType() == ApplicationDocumentType.RESUME);
                     boolean portfolioRegistered = ja.getApplicationDocuments().stream()
                             .anyMatch(d -> d.getDocType() == ApplicationDocumentType.PORTFOLIO);
-                            
+
                     boolean isProcessing = analysisService.isProcessing(ja.getId());
-                    return MyApplicationResponse.from(ja, score, isProcessing, resumeAnalyzed, portfolioAnalyzed, resumeRegistered, portfolioRegistered);
+                    return MyApplicationResponse.from(ja, score, isProcessing, resumeAnalyzed, portfolioAnalyzed,
+                            resumeRegistered, portfolioRegistered);
                 })
                 .toList();
     }


### PR DESCRIPTION
- 지원서와 서류(이력서/포폴) 데이터를 Join Fetch로 한 번에 가져오도록 수정
- 분석 점수 및 상태값을 Batch Fetch로 처리하여 성능 개선 및 지연 로딩 오류 방지