### PR TITLE
 feat : 알림 — AI 비교 분석 완료 / 채팅방 강퇴 / 채팅방 종료

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -20,9 +20,12 @@ import com.thunder11.scuad.jobposting.repository.ApplicationDocumentRepository;
 import com.thunder11.scuad.jobposting.repository.JobApplicationRepository;
 import com.thunder11.scuad.file.service.S3FileManagementService;
 import com.thunder11.scuad.jobposting.repository.JobMasterRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.thunder11.scuad.notification.event.ChatRoomNotificationEvent;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +58,7 @@ public class ChatRoomService {
     private final UserRepository userRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final S3FileManagementService s3FileManagementService;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 사용자의 AI 평가 점수 조회 (private 헬퍼 메서드)
     private Integer getMyScore(Long userId, Long jobMasterId) {
@@ -554,6 +558,11 @@ public class ChatRoomService {
         //           나가기 시도 시 에러를 던지는 대신 채팅방을 자동 종료
         if (member.getRole() == MemberRole.HOST) {
             log.info("방장의 나가기 시도 → 채팅방 자동 종료: chatRoomId={}, userId={}", chatRoomId, userId);
+
+            // 종료 처리 전에 활성 멤버 조회 (chatRoom.close() 이후에도 kicked_at IS NULL 조건은 유지되므로
+            // 순서 무관하지만, 의도를 명확히 하기 위해 종료 전에 조회)
+            List<ChatRoomMember> activeMembers = chatRoomMemberRepository.findAllActiveMembersByChatRoomId(chatRoomId);
+
             chatRoom.close();
             chatRoomRepository.save(chatRoom);
 
@@ -563,6 +572,17 @@ public class ChatRoomService {
             );
             chatMessageRepository.save(systemMessage);
             log.info("방장 나가기로 인한 채팅방 종료 완료: chatRoomId={}", chatRoomId);
+
+            // 방장 제외 활성 멤버 전원에게 종료 알림 발행
+            activeMembers.stream()
+                    .filter(m -> !m.getUserId().equals(userId))
+                    .forEach(m -> eventPublisher.publishEvent(new ChatRoomNotificationEvent(
+                            m.getUserId(),
+                            "CHAT_ROOM_CLOSED",
+                            chatRoom.getRoomName(),
+                            chatRoomId
+                    )));
+            log.info("채팅방 종료 알림 이벤트 발행 완료 (방장 자동 종료): chatRoomId={}", chatRoomId);
             return;
         }
 
@@ -642,6 +662,20 @@ public class ChatRoomService {
         chatMessageRepository.save(systemMessage);
         log.info("강퇴 시스템 메시지 생성 완료: chatRoomId={}, kickedUserId={}",
                 chatRoomId, targetMember.getUserId());
+
+        // 10. 강퇴된 사용자에게 알림 발행
+        // @TransactionalEventListener(AFTER_COMMIT)로 커밋 이후 수신되므로
+        // 트랜잭션 롤백 시 알림이 발송되지 않는다.
+        String chatRoomName = chatRoomRepository.findByIdNotDeleted(chatRoomId)
+                .map(ChatRoom::getRoomName)
+                .orElse("채팅방");
+        eventPublisher.publishEvent(new ChatRoomNotificationEvent(
+                targetMember.getUserId(),
+                "CHAT_ROOM_KICKED",
+                chatRoomName,
+                chatRoomId
+        ));
+        log.info("강퇴 알림 이벤트 발행: chatRoomId={}, kickedUserId={}", chatRoomId, targetMember.getUserId());
     }
 
     // 채팅방 종료
@@ -667,6 +701,9 @@ public class ChatRoomService {
         }
 
         // 4. 채팅방 종료
+        // 종료 전에 활성 멤버 조회 (방장 제외 알림 발송용)
+        List<ChatRoomMember> activeMembers = chatRoomMemberRepository.findAllActiveMembersByChatRoomId(chatRoomId);
+
         chatRoom.close();
         chatRoomRepository.save(chatRoom);
         log.info("채팅방 종료 완료: chatRoomId={}", chatRoomId);
@@ -678,6 +715,17 @@ public class ChatRoomService {
         );
         chatMessageRepository.save(systemMessage);
         log.info("종료 시스템 메시지 생성 완료: chatRoomId={}", chatRoomId);
+
+        // 6. 방장 제외 활성 멤버 전원에게 종료 알림 발행
+        activeMembers.stream()
+                .filter(m -> !m.getUserId().equals(userId))
+                .forEach(m -> eventPublisher.publishEvent(new ChatRoomNotificationEvent(
+                        m.getUserId(),
+                        "CHAT_ROOM_CLOSED",
+                        chatRoom.getRoomName(),
+                        chatRoomId
+                )));
+        log.info("채팅방 종료 알림 이벤트 발행 완료 (명시적 종료): chatRoomId={}", chatRoomId);
     }
 
     // 채팅방 멤버 목록 조회

--- a/src/main/java/com/thunder11/scuad/notification/event/ChatRoomNotificationEvent.java
+++ b/src/main/java/com/thunder11/scuad/notification/event/ChatRoomNotificationEvent.java
@@ -1,0 +1,21 @@
+package com.thunder11.scuad.notification.event;
+
+/**
+ * 채팅방 관련 알림 이벤트
+ *
+ * AiAnalysisCompleteEvent와 동일한 패턴으로 설계.
+ * ChatRoomService에서 publishEvent()로 발행하고,
+ * NotificationService의 @TransactionalEventListener(AFTER_COMMIT)가 수신하여
+ * 트랜잭션 커밋 이후 알림을 발송한다.
+ *
+ * @param userId          알림 수신 대상 userId
+ * @param type            알림 타입 (CHAT_ROOM_KICKED / CHAT_ROOM_CLOSED)
+ * @param chatRoomName    알림 본문에 사용할 채팅방 이름
+ * @param chatRoomId      refId로 사용할 채팅방 ID
+ */
+public record ChatRoomNotificationEvent(
+        Long userId,
+        String type,
+        String chatRoomName,
+        Long chatRoomId
+) {}

--- a/src/main/java/com/thunder11/scuad/notification/service/NotificationService.java
+++ b/src/main/java/com/thunder11/scuad/notification/service/NotificationService.java
@@ -15,6 +15,7 @@ import com.thunder11.scuad.notification.dto.request.SseNotificationEvent;
 import com.thunder11.scuad.notification.dto.response.NotificationResponse;
 import com.thunder11.scuad.notification.repository.NotificationRepository;
 import com.thunder11.scuad.notification.event.AiAnalysisCompleteEvent;
+import com.thunder11.scuad.notification.event.ChatRoomNotificationEvent;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +35,24 @@ public class NotificationService {
             createAndPush(event.userId(), event.type(), event.jobPostingTitle(), event.applicationId());
         } catch (Exception e) {
             log.error("알림 발송 오류: {}", e.getMessage());
+        }
+    }
+
+    // 채팅방 강퇴 / 종료 알림 핸들러
+    //
+    // AiAnalysisCompleteEvent 핸들러와 동일한 패턴으로 구현.
+    // ChatRoomService의 @Transactional 메서드 내부에서 publishEvent()를 호출하면
+    // 트랜잭션 커밋 이후 이 핸들러가 수신하여 알림을 발송한다.
+    // REQUIRES_NEW를 사용하는 이유: 알림 발송 실패가 채팅방 비즈니스 로직 트랜잭션에
+    // 영향을 주지 않도록 독립된 트랜잭션으로 처리한다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleChatRoomNotification(ChatRoomNotificationEvent event) {
+        try {
+            createAndPush(event.userId(), event.type(), event.chatRoomName(), event.chatRoomId());
+        } catch (Exception e) {
+            log.error("채팅방 알림 발송 오류: userId={}, type={}, error={}",
+                    event.userId(), event.type(), e.getMessage());
         }
     }
 

--- a/src/main/java/com/thunder11/scuad/notification/service/NotificationService.java
+++ b/src/main/java/com/thunder11/scuad/notification/service/NotificationService.java
@@ -67,6 +67,20 @@ public class NotificationService {
                 title = safeJobTitle + " 포트폴리오 분석";
                 body = "포트폴리오 분석 결과를 확인하세요!";
             }
+            case "COMPARISON_COMPLETE" -> {
+                title = safeJobTitle + " 비교 분석 완료";
+                body = "AI 비교 분석 결과를 확인해보세요.";
+            }
+            case "CHAT_ROOM_KICKED" -> {
+                title = "채팅방에서 강퇴되었습니다.";
+                body = safeJobTitle + " 채팅방에서 내보내졌습니다.";
+                refType = "CHAT_ROOM";
+            }
+            case "CHAT_ROOM_CLOSED" -> {
+                title = "채팅방이 종료되었습니다.";
+                body = safeJobTitle + " 채팅방이 종료되었습니다.";
+                refType = "CHAT_ROOM";
+            }
             default -> {
                 title = safeJobTitle + " 시스템 알림";
                 body = "처리가 완료되었습니다.";


### PR DESCRIPTION
## 개요

알림 도메인의 기존 SSE 인프라(`SseEmitterRegistry`, `NotificationService`)를 활용하여
미구현 상태였던 세 가지 인앱 알림을 추가합니다.

- AI 비교 분석 완료 (`COMPARISON_COMPLETE`)
- 채팅방 강퇴 (`CHAT_ROOM_KICKED`)
- 채팅방 종료 (`CHAT_ROOM_CLOSED`)

---

## 변경 파일

- `notification/event/ChatRoomNotificationEvent.java` (신규)
- `notification/service/NotificationService.java` (수정)
- `chat/service/ChatRoomService.java` (수정)

---

## 작업 상세 및 의도

### 1. `COMPARISON_COMPLETE` — switch 케이스 누락 수정

**왜 이렇게 했나**

`AiResultProcessingService`에서 `createAndPush(userId, "COMPARISON_COMPLETE", ...)`
호출은 이미 존재했지만, `NotificationService`의 switch 문에 해당 케이스가 없었습니다.
결과적으로 default 분기로 빠지며 "시스템 알림 / 처리가 완료되었습니다." 라는
의도하지 않은 문구로 알림이 발송되고 있었습니다.
별도 호출 구조 변경 없이 switch 케이스만 추가하여 최소 범위로 수정했습니다.

**검수 포인트**

- AI 비교 분석 완료 후 토스트 알림 문구가 `{공고명} 비교 분석 완료 / AI 비교 분석 결과를 확인해보세요.`로 표시되는지 확인
- `refType`이 `APPLICATION`, `refId`가 `applicationId`로 저장되는지 확인

---

### 2. `ChatRoomNotificationEvent` 신규 생성 + 핸들러 추가

**왜 이렇게 했나**

채팅방 강퇴/종료 알림을 Controller에서 직접 호출하는 방식 대신,
기존 `AiAnalysisCompleteEvent` + `@TransactionalEventListener(AFTER_COMMIT)` 패턴을 그대로 따랐습니다.

이 패턴을 선택한 이유는 두 가지입니다.

첫째, **트랜잭션 안전성** — `@Transactional` 메서드 내부에서 직접 알림을 발송하면
트랜잭션 커밋 전에 알림이 나갈 수 있습니다. `AFTER_COMMIT`을 사용하면
커밋이 확정된 이후에만 알림이 발송되므로 롤백 시 알림이 나가는 문제를 방지합니다.

둘째, **알림 실패의 비즈니스 로직 격리** — `REQUIRES_NEW`를 적용하여 알림 발송 실패가
채팅방 강퇴/종료 트랜잭션에 영향을 주지 않도록 독립된 트랜잭션으로 처리했습니다.
강퇴/종료는 완료되었는데 알림 실패로 인해 롤백되는 상황을 방지합니다.

**검수 포인트**

- `handleChatRoomNotification()`이 `handleAiAnalysisComplete()`와 동일하게
  `@TransactionalEventListener(AFTER_COMMIT)` + `@Transactional(REQUIRES_NEW)`로
  선언되어 있는지 확인
- 이벤트 파라미터 `chatRoomName`이 `createAndPush()`의 `jobPostingTitle` 자리에 들어가고,
  `chatRoomId`가 `refId` 자리에 들어가는 흐름이 의도대로인지 확인
  (기존 `createAndPush()` 시그니처를 재사용했기 때문에 파라미터 의미가 맞지 않게 보일 수 있음)

---

### 3. `ChatRoomService` — 이벤트 발행 지점 3곳 추가

**왜 이렇게 했나**

`kickMember()`, `leaveChatRoom()` HOST 분기, `closeChatRoom()` 각각의 마지막 단계에서
`ApplicationEventPublisher.publishEvent()`를 호출합니다.

채팅방 종료 알림(`CHAT_ROOM_CLOSED`)에서 **방장을 수신 대상에서 제외**한 이유는
방장 본인이 직접 종료를 실행한 당사자이므로 알림이 불필요하기 때문입니다.

`leaveChatRoom()` HOST 분기에서는 `chatRoom.close()` 호출 전에
`findAllActiveMembersByChatRoomId()`로 멤버 목록을 먼저 조회했습니다.
종료 후에 조회해도 `kicked_at IS NULL` 조건은 변함없어 결과는 동일하지만,
"종료 전 멤버 목록을 기준으로 알림을 보낸다"는 의도를 코드에서 명확히 드러내기 위해
순서를 앞에 배치했습니다.

**검수 포인트**

- `kickMember()`: 강퇴 대상(`targetMember.getUserId()`)에게만 알림이 발행되는지 확인.
  강퇴를 실행한 방장에게는 알림이 가지 않는지 확인
- `leaveChatRoom()` HOST 분기: 방장 `userId`를 filter로 제외한 뒤 나머지 멤버에게만
  이벤트가 발행되는지 확인
- `closeChatRoom()`: 동일하게 방장(`userId`) 제외 확인
- 두 종료 경로(`leaveChatRoom` HOST 분기, `closeChatRoom`) 모두에서 알림이 발행되는지 확인
  (한쪽 경로만 동작하는 누락 없는지)
- `ChatRoomService`에 `ApplicationEventPublisher` 필드가 `@RequiredArgsConstructor`로
  정상 주입되는지 빌드 후 확인

---

## 알림 명세 (최종)

| type | 수신 대상 | title | body | refType | refId |
|---|---|---|---|---|---|
| `COMPARISON_COMPLETE` | 비교 분석 요청자 | `{공고명} 비교 분석 완료` | `AI 비교 분석 결과를 확인해보세요.` | `APPLICATION` | `applicationId` |
| `CHAT_ROOM_KICKED` | 강퇴된 멤버 본인 | `채팅방에서 강퇴되었습니다.` | `{채팅방명} 채팅방에서 내보내졌습니다.` | `CHAT_ROOM` | `chatRoomId` |
| `CHAT_ROOM_CLOSED` | 채팅방 활성 멤버 전원 (방장 제외) | `채팅방이 종료되었습니다.` | `{채팅방명} 채팅방이 종료되었습니다.` | `CHAT_ROOM` | `chatRoomId` |

---

## 한계 및 향후 고려사항

`NotificationService.createAndPush()`의 메서드 시그니처가
`(userId, type, jobPostingTitle, applicationId)` 로 설계되어 있어
채팅방 알림에서는 `jobPostingTitle` 자리에 `chatRoomName`을,
`applicationId` 자리에 `chatRoomId`를 넣는 구조입니다.
현재는 동작에 문제가 없지만, 파라미터 의미가 맞지 않아 가독성이 떨어집니다.
추후 `createAndPush()` 시그니처를 범용화하거나 오버로드로 분리하는 것을 고려할 수 있습니다.