### PR TITLE
채팅방 리스트에 SSE + Redis Pub/Sub 도입

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -18,6 +18,7 @@ import com.thunder11.scuad.auth.security.UserPrincipal;
 import com.thunder11.scuad.chat.service.ChatMessageService;
 import com.thunder11.scuad.chat.service.ChatRoomService;
 import com.thunder11.scuad.common.response.ApiResponse;
+import com.thunder11.scuad.infra.redis.SseEventPublisher;
 
 // 채팅방 관련 API 컨트롤러
 @Slf4j
@@ -31,6 +32,7 @@ public class ChatRoomController {
     private final com.thunder11.scuad.file.service.FileStorageService fileStorageService;
     private final ChatMemberDocumentService chatMemberDocumentService;
     private final ChatMemberComparisonService chatMemberComparisonService;
+    private final SseEventPublisher sseEventPublisher;
 
     // 공고별 채팅방 목록 조회
     @GetMapping("/job-postings/{jobMasterId}/chat-rooms")
@@ -114,6 +116,11 @@ public class ChatRoomController {
                 chatRoomId, userPrincipal.getUserId());
 
         chatRoomService.joinChatRoom(chatRoomId, userPrincipal.getUserId());
+
+        // 트랜잭션 커밋 완료 후 SSE 이벤트 publish
+        // joinChatRoom() 리턴 = 커밋 완료 시점이므로 이 시점 이후 publish해야
+        // 클라이언트가 이벤트 수신 후 멤버 목록 재조회 시 최신 데이터를 받을 수 있음
+        sseEventPublisher.publishMemberJoined(chatRoomId);
 
         return ApiResponse.of(
                 HttpStatus.OK.value(),
@@ -289,6 +296,14 @@ public class ChatRoomController {
 
         chatRoomService.leaveChatRoom(chatRoomId, userPrincipal.getUserId());
 
+        // leaveChatRoom()은 void이므로 방장 자동 종료 여부를 직접 알 수 없음.
+        // 커밋 완료 후 채팅방 상태를 조회하여 CLOSED면 ROOM_CLOSED, 아니면 MEMBER_LEFT publish.
+        // DB 조회가 1회 추가되지만 leaveChatRoom() 반환 타입을 바꾸는 것보다
+        // 기존 Service 시그니처를 유지하는 쪽이 변경 영향 범위가 작아 이 방식을 선택.
+        chatRoomService.isRoomClosed(chatRoomId)
+                ? sseEventPublisher.publishRoomClosed(chatRoomId)
+                : sseEventPublisher.publishMemberLeft(chatRoomId);
+
         return ApiResponse.of(
                 HttpStatus.OK.value(),
                 "CHAT_ROOM_LEFT",
@@ -308,6 +323,12 @@ public class ChatRoomController {
 
         chatRoomService.kickMember(chatRoomId, userPrincipal.getUserId(), chatRoomMemberId);
 
+        // kickMember()는 chatRoomMemberId 기준으로 강퇴하므로
+        // 강퇴된 userId를 Controller에서 직접 알 수 없음.
+        // SseEventPublisher.publishMemberKicked()는 chatRoomMemberId를 받아
+        // 내부에서 userId를 조회하는 방식으로 처리.
+        sseEventPublisher.publishMemberKicked(chatRoomId, chatRoomMemberId);
+
         return ApiResponse.of(
                 HttpStatus.OK.value(),
                 "MEMBER_KICKED",
@@ -325,6 +346,8 @@ public class ChatRoomController {
                 chatRoomId, userPrincipal.getUserId());
 
         chatRoomService.closeChatRoom(chatRoomId, userPrincipal.getUserId());
+
+        sseEventPublisher.publishRoomClosed(chatRoomId);
 
         return ApiResponse.of(
                 HttpStatus.OK.value(),

--- a/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/thunder11/scuad/chat/controller/ChatRoomController.java
@@ -298,11 +298,12 @@ public class ChatRoomController {
 
         // leaveChatRoom()은 void이므로 방장 자동 종료 여부를 직접 알 수 없음.
         // 커밋 완료 후 채팅방 상태를 조회하여 CLOSED면 ROOM_CLOSED, 아니면 MEMBER_LEFT publish.
-        // DB 조회가 1회 추가되지만 leaveChatRoom() 반환 타입을 바꾸는 것보다
-        // 기존 Service 시그니처를 유지하는 쪽이 변경 영향 범위가 작아 이 방식을 선택.
-        chatRoomService.isRoomClosed(chatRoomId)
-                ? sseEventPublisher.publishRoomClosed(chatRoomId)
-                : sseEventPublisher.publishMemberLeft(chatRoomId);
+        if (chatRoomService.isRoomClosed(chatRoomId)) {
+            sseEventPublisher.publishRoomClosed(chatRoomId);
+        } else {
+            sseEventPublisher.publishMemberLeft(chatRoomId);
+        }
+
 
         return ApiResponse.of(
                 HttpStatus.OK.value(),

--- a/src/main/java/com/thunder11/scuad/chat/dto/ChatSseEvent.java
+++ b/src/main/java/com/thunder11/scuad/chat/dto/ChatSseEvent.java
@@ -1,0 +1,25 @@
+package com.thunder11.scuad.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 채팅방 상태 변경 SSE 이벤트 DTO
+ *
+ * SseEventPublisher → Redis publish → SseEventSubscriber → SseEmitterRegistry.sendChatEvent()
+ * 흐름으로 전달되는 페이로드.
+ *
+ * currentParticipants: MEMBER_JOINED / MEMBER_LEFT / MEMBER_KICKED 에서 사용.
+ *                      ROOM_CLOSED는 인원수가 의미 없으므로 null로 전달.
+ * kickedUserId:        MEMBER_KICKED 에서만 사용.
+ *                      클라이언트가 본인이 강퇴 대상인지 판별하는 데 사용.
+ *                      다른 이벤트 타입에서는 null.
+ */
+@Getter
+@Builder
+public class ChatSseEvent {
+    private String type;
+    private Long chatRoomId;
+    private Integer currentParticipants;
+    private Long kickedUserId;
+}

--- a/src/main/java/com/thunder11/scuad/chat/dto/ChatSseEvent.java
+++ b/src/main/java/com/thunder11/scuad/chat/dto/ChatSseEvent.java
@@ -2,6 +2,8 @@ package com.thunder11.scuad.chat.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
 /**
  * 채팅방 상태 변경 SSE 이벤트 DTO
@@ -17,6 +19,8 @@ import lombok.Getter;
  */
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ChatSseEvent {
     private String type;
     private Long chatRoomId;

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -539,6 +539,17 @@ public class ChatRoomService {
         log.info("입장 시스템 메시지 생성 완료: chatRoomId={}, userId={}", chatRoomId, userId);
     }
 
+    // 채팅방 종료 여부 확인 (Controller에서 SSE 이벤트 분기용)
+    //
+    // leaveChatRoom()이 void이므로 방장 자동 종료 여부를 Controller에서 알 수 없음.
+    // 반환 타입 변경 없이 Service 시그니처를 유지하면서 Controller가 종료 여부를
+    // 판단할 수 있도록 별도 조회 메서드를 제공.
+    public boolean isRoomClosed(Long chatRoomId) {
+        return chatRoomRepository.findByIdNotDeleted(chatRoomId)
+                .map(room -> room.getStatus() == RoomStatus.CLOSED)
+                .orElse(true); // 방이 없으면 종료된 것으로 간주
+    }
+
     // 채팅방 퇴장
     @Transactional
     public void leaveChatRoom(Long chatRoomId, Long userId) {

--- a/src/main/java/com/thunder11/scuad/infra/redis/SseEventPublisher.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/SseEventPublisher.java
@@ -1,0 +1,92 @@
+package com.thunder11.scuad.infra.redis;
+
+import com.thunder11.scuad.chat.dto.ChatSseEvent;
+import com.thunder11.scuad.chat.repository.ChatRoomMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 채팅방 상태 변경 이벤트를 Redis 채널에 publish하는 컴포넌트
+ *
+ * 호출 위치: ChatRoomController — Service 메서드 리턴(= 트랜잭션 커밋 완료) 후 즉시 호출
+ *
+ * 트랜잭션 커밋 후에 호출해야 하는 이유:
+ *   @Transactional 메서드 내부에서 publish하면 커밋 전에 이벤트가 나가므로
+ *   클라이언트가 이벤트 수신 후 즉시 멤버 목록/인원수를 조회하면
+ *   DB에 아직 반영되지 않은 데이터를 받는 레이스 컨디션이 발생한다.
+ *   ChatMessageService.broadcast()와 동일한 원칙을 따른다.
+ *
+ * Redis 채널명 규칙: chat-sse:{chatRoomId}
+ *   기존 채팅 메시지 채널(chat-room:*)과 분리하여
+ *   SseEventSubscriber가 WebSocket 브로드캐스트 없이 SSE push만 처리하도록 역할을 명확히 구분
+ *
+ * @ConditionalOnProperty 미적용 이유:
+ *   chatRedisTemplate이 @Autowired(required = false)로 주입되므로
+ *   Redis 비활성화 환경에서 빈이 없어도 컨텍스트 로드에 문제없음.
+ *   publish() 호출 시 null 체크로 안전하게 처리.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseEventPublisher {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    // required = false 적용 근거:
+    //   RedisPubSubConfig가 @ConditionalOnProperty로 조건부 로드되므로
+    //   Redis 비활성화 환경(테스트, 로컬)에서는 chatRedisTemplate 빈이 존재하지 않음.
+    //   ChatMessageService.broadcast()와 동일한 패턴으로 처리.
+    @Autowired(required = false)
+    @Qualifier("chatRedisTemplate")
+    private RedisTemplate<String, Object> redisTemplate;
+
+    public void publishMemberJoined(Long chatRoomId) {
+        long currentParticipants = chatRoomMemberRepository.countByChatRoomIdAndKickedAtIsNull(chatRoomId);
+        publish(chatRoomId, ChatSseEvent.builder()
+                .type("MEMBER_JOINED")
+                .chatRoomId(chatRoomId)
+                .currentParticipants((int) currentParticipants)
+                .build());
+    }
+
+    public void publishMemberLeft(Long chatRoomId) {
+        long currentParticipants = chatRoomMemberRepository.countByChatRoomIdAndKickedAtIsNull(chatRoomId);
+        publish(chatRoomId, ChatSseEvent.builder()
+                .type("MEMBER_LEFT")
+                .chatRoomId(chatRoomId)
+                .currentParticipants((int) currentParticipants)
+                .build());
+    }
+
+    public void publishMemberKicked(Long chatRoomId, Long kickedUserId) {
+        long currentParticipants = chatRoomMemberRepository.countByChatRoomIdAndKickedAtIsNull(chatRoomId);
+        publish(chatRoomId, ChatSseEvent.builder()
+                .type("MEMBER_KICKED")
+                .chatRoomId(chatRoomId)
+                .currentParticipants((int) currentParticipants)
+                .kickedUserId(kickedUserId)
+                .build());
+    }
+
+    public void publishRoomClosed(Long chatRoomId) {
+        publish(chatRoomId, ChatSseEvent.builder()
+                .type("ROOM_CLOSED")
+                .chatRoomId(chatRoomId)
+                .build());
+    }
+
+    private void publish(Long chatRoomId, ChatSseEvent event) {
+        if (redisTemplate == null) {
+            log.warn("Redis Pub/Sub 비활성화 상태 — SSE 이벤트 publish 스킵: chatRoomId={}, type={}",
+                    chatRoomId, event.getType());
+            return;
+        }
+        String channel = "chat-sse:" + chatRoomId;
+        redisTemplate.convertAndSend(channel, event);
+        log.info("SSE 이벤트 publish 완료: channel={}, type={}", channel, event.getType());
+    }
+}

--- a/src/main/java/com/thunder11/scuad/infra/redis/SseEventPublisher.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/SseEventPublisher.java
@@ -62,8 +62,13 @@ public class SseEventPublisher {
                 .build());
     }
 
-    public void publishMemberKicked(Long chatRoomId, Long kickedUserId) {
+    public void publishMemberKicked(Long chatRoomId, Long chatRoomMemberId) {
         long currentParticipants = chatRoomMemberRepository.countByChatRoomIdAndKickedAtIsNull(chatRoomId);
+        // chatRoomMemberId로 강퇴된 userId 조회
+        // kicked_at이 설정된 직후이므로 kicked 상태로 조회해야 함
+        Long kickedUserId = chatRoomMemberRepository.findById(chatRoomMemberId)
+                .map(m -> m.getUserId())
+                .orElse(null);
         publish(chatRoomId, ChatSseEvent.builder()
                 .type("MEMBER_KICKED")
                 .chatRoomId(chatRoomId)

--- a/src/main/java/com/thunder11/scuad/infra/redis/SseEventSubscriber.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/SseEventSubscriber.java
@@ -1,0 +1,68 @@
+package com.thunder11.scuad.infra.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thunder11.scuad.chat.dto.ChatSseEvent;
+import com.thunder11.scuad.chat.repository.ChatRoomMemberRepository;
+import com.thunder11.scuad.notification.service.SseEmitterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis chat-sse:* 채널 구독자
+ *
+ * 역할: Redis 채널(chat-sse:{chatRoomId})에서 이벤트를 수신하여
+ *       해당 채팅방의 활성 멤버 전원에게 SSE push
+ *
+ * 기존 RedisSubscriber와 분리한 이유:
+ *   RedisSubscriber → WebSocket 브로드캐스트 (채팅 메시지 전달용)
+ *   SseEventSubscriber → SSE push (채팅방 상태 변경 알림용)
+ *   두 클래스의 처리 방식이 완전히 달라 하나의 클래스에 합치면 단일 책임 원칙을 위반하고
+ *   이후 변경 시 영향 범위를 파악하기 어려워짐.
+ *
+ * 다중 서버 이벤트 전파 흐름:
+ *   서버B에서 joinChatRoom() 실행
+ *     → SseEventPublisher.publishMemberJoined() → Redis publish("chat-sse:1")
+ *                                                          ↓
+ *                                                   Redis Pub/Sub
+ *                                                          ↓
+ *                     서버A SseEventSubscriber.onMessage() → 서버A 연결 클라이언트 push ✅
+ *                     서버B SseEventSubscriber.onMessage() → 서버B 연결 클라이언트 push ✅
+ *
+ * Map 대신 ChatSseEvent로 역직렬화하는 이유:
+ *   ChatSseEvent는 @Builder만 선언되어 있어 기본 생성자가 없으므로
+ *   RedisSubscriber처럼 Map<String, Object>로 역직렬화한 뒤
+ *   ObjectMapper로 ChatSseEvent로 변환하는 방식을 사용한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SseEventSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final SseEmitterRegistry sseEmitterRegistry;
+
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            Long chatRoomId = Long.parseLong(channel.replace("chat-sse:", ""));
+
+            ChatSseEvent event = objectMapper.readValue(message.getBody(), ChatSseEvent.class);
+
+            // 해당 채팅방의 활성 멤버 전원에게 SSE push
+            // 다중 서버 환경에서는 각 서버가 자신에게 연결된 Emitter만 보유하므로
+            // sendChatEvent() 내부에서 emitters.get(userId)가 null이면 조용히 스킵됨
+            chatRoomMemberRepository.findAllActiveMembersByChatRoomId(chatRoomId)
+                    .forEach(member -> sseEmitterRegistry.sendChatEvent(member.getUserId(), event));
+
+            log.info("SSE 이벤트 브로드캐스트 완료: chatRoomId={}, type={}", chatRoomId, event.getType());
+
+        } catch (Exception e) {
+            log.error("SSE 이벤트 처리 실패: channel={}, error={}",
+                    new String(message.getChannel()), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/thunder11/scuad/infra/redis/config/RedisPubSubConfig.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/config/RedisPubSubConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.thunder11.scuad.infra.redis.RedisSubscriber;
+import com.thunder11.scuad.infra.redis.SseEventSubscriber;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -34,6 +35,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisPubSubConfig {
 
     private final RedisSubscriber redisSubscriber;
+    private final SseEventSubscriber sseEventSubscriber;
 
     // Pub/Sub 전용 RedisTemplate
     //
@@ -68,6 +70,17 @@ public class RedisPubSubConfig {
         return new MessageListenerAdapter(redisSubscriber, "onMessage");
     }
 
+    // SSE 이벤트 수신 핸들러 어댑터
+    //
+    // SseEventSubscriber.onMessage()를 chat-sse:* 채널 수신 콜백으로 등록
+    // messageListenerAdapter()와 별도 빈으로 분리한 이유:
+    //   동일한 컨테이너에 두 리스너를 등록하되 각각 다른 어댑터를 사용해야
+    //   채팅 메시지(WebSocket)와 SSE 이벤트 처리가 완전히 독립적으로 동작함
+    @Bean
+    public MessageListenerAdapter sseMessageListenerAdapter() {
+        return new MessageListenerAdapter(sseEventSubscriber, "onMessage");
+    }
+
     // Redis 채널 구독 컨테이너
     //
     // chat-room:* 패턴의 모든 채널 구독 (채팅방 ID별 채널 분리)
@@ -78,11 +91,18 @@ public class RedisPubSubConfig {
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
-            MessageListenerAdapter messageListenerAdapter
+            MessageListenerAdapter messageListenerAdapter,
+            MessageListenerAdapter sseMessageListenerAdapter
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
+        // 채팅 메시지 브로드캐스트 채널 (기존)
         container.addMessageListener(messageListenerAdapter, new PatternTopic("chat-room:*"));
+        // 채팅방 상태 변경 SSE 알림 채널 (신규)
+        // chat-room:* 와 채널 패턴을 분리한 이유:
+        //   두 채널의 Subscriber 처리 방식이 완전히 달라(WebSocket vs SSE)
+        //   하나의 패턴으로 묶으면 분기 처리 로직이 복잡해지고 변경 영향 범위가 커짐
+        container.addMessageListener(sseMessageListenerAdapter, new PatternTopic("chat-sse:*"));
         return container;
     }
 }

--- a/src/main/java/com/thunder11/scuad/notification/service/SseEmitterRegistry.java
+++ b/src/main/java/com/thunder11/scuad/notification/service/SseEmitterRegistry.java
@@ -10,6 +10,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import lombok.extern.slf4j.Slf4j;
 
 import com.thunder11.scuad.notification.dto.request.SseNotificationEvent;
+import com.thunder11.scuad.chat.dto.ChatSseEvent;
 
 @Slf4j
 @Component
@@ -76,6 +77,31 @@ public class SseEmitterRegistry {
                 log.info("SSE 토스트 발송 완료 userId={}, notificationId={}", userId, event.getNotificationId());
             } catch (Exception e) {
                 log.warn("SSE 전송 실패. 커넥션 해제 userId={}", userId);
+                emitters.remove(userId, emitter);
+            }
+        }
+    }
+
+    // 채팅방 상태 변경 이벤트 전송
+    //
+    // 기존 send()와 분리한 이유:
+    //   기존 send()는 이벤트명이 "notification"으로 하드코딩되어 있어
+    //   클라이언트가 알림 토스트와 채팅방 상태 변경을 이벤트명으로 구분할 수 없음.
+    //   "chat-room-update"라는 별도 이벤트명을 사용하여
+    //   클라이언트가 EventSource 리스너에서 용도별로 분기 처리할 수 있도록 함.
+    public void sendChatEvent(Long userId, ChatSseEvent event) {
+        SseEmitter emitter = emitters.get(userId);
+        if (emitter != null) {
+            try {
+                synchronized (emitter) {
+                    emitter.send(SseEmitter.event()
+                            .name("chat-room-update")
+                            .data(event));
+                }
+                log.info("채팅방 SSE 이벤트 발송 완료: userId={}, type={}, chatRoomId={}",
+                        userId, event.getType(), event.getChatRoomId());
+            } catch (Exception e) {
+                log.warn("채팅방 SSE 전송 실패. 커넥션 해제: userId={}", userId);
                 emitters.remove(userId, emitter);
             }
         }


### PR DESCRIPTION
## 개요

채팅방 목록에서 인원수와 채팅방 상태(ACTIVE/CLOSED)가 새로고침 없이는 반영되지 않는 문제를 SSE + Redis Pub/Sub 도입으로 해결합니다.
운영 환경이 다중 서버로 구성되어 있어 단순 SSE만으로는 이벤트 유실이 발생하므로, 기존 채팅 메시지 브로드캐스트와 동일하게 Redis Pub/Sub을 경유하는 구조로 설계했습니다.

---

## 변경 파일

**신규 생성 (3개)**
- `chat/dto/ChatSseEvent.java`
- `infra/redis/SseEventPublisher.java`
- `infra/redis/SseEventSubscriber.java`

**기존 수정 (4개)**
- `notification/service/SseEmitterRegistry.java`
- `infra/redis/config/RedisPubSubConfig.java`
- `chat/service/ChatRoomService.java`
- `chat/controller/ChatRoomController.java`

---

## 전체 흐름
```
ChatRoomController
  chatRoomService.joinChatRoom()          ← @Transactional (커밋)
  sseEventPublisher.publishMemberJoined() ← 커밋 후 publish
        │
        ▼
chatRedisTemplate.convertAndSend("chat-sse:{chatRoomId}", ChatSseEvent)
        │
        ▼
Redis Pub/Sub (chat-sse:* 채널)
        │
        ├──▶ 서버A SseEventSubscriber.onMessage()
        │       → findAllActiveMembersByChatRoomId()
        │       → SseEmitterRegistry.sendChatEvent(userId, event) × N ✅
        │
        └──▶ 서버B SseEventSubscriber.onMessage()
                → 동일하게 처리 ✅
```

---

## 작업 상세 및 의도

### 1. `ChatSseEvent` DTO

SSE 전용 이벤트 페이로드입니다.

`currentParticipants`는 `MEMBER_JOINED` / `MEMBER_LEFT` / `MEMBER_KICKED`에서 사용하고
`ROOM_CLOSED`는 인원수가 의미 없으므로 null로 전달합니다.

`kickedUserId`는 `MEMBER_KICKED`에서만 사용하며 클라이언트가 본인이 강퇴 대상인지 판별하는 데 씁니다.

`@NoArgsConstructor` / `@AllArgsConstructor`를 함께 추가한 이유는
Redis에서 역직렬화 시 Jackson이 기본 생성자를 필요로 하기 때문입니다.
`@Builder`만 있으면 역직렬화 단계에서 실패합니다.

**검수 포인트**

- `ROOM_CLOSED` 이벤트 수신 시 `currentParticipants`가 null인지 확인
- `MEMBER_KICKED` 외 이벤트에서 `kickedUserId`가 null인지 확인

---

### 2. `SseEmitterRegistry.sendChatEvent()`

기존 `send()`와 별도 메서드로 분리한 이유는 이벤트명 때문입니다.
```
기존 send()       → 이벤트명: "notification"  (알림 토스트용)
sendChatEvent()   → 이벤트명: "chat-room-update" (채팅방 상태 변경용)
```

클라이언트가 `EventSource` 리스너에서 `addEventListener("notification", ...)` 와
`addEventListener("chat-room-update", ...)` 로 용도별로 분기 처리할 수 있도록 이름을 분리했습니다.
하나의 이벤트명으로 합치면 클라이언트에서 `type` 필드로 다시 분기해야 하는 불필요한 복잡도가 생깁니다.

**검수 포인트**

- `sendChatEvent()` 호출 시 실제 EventSource에서 이벤트명이 `chat-room-update`로 수신되는지 확인
- Emitter가 없는 userId(오프라인 사용자)에 대해 조용히 스킵되는지 확인

---

### 3. `SseEventPublisher`

`ChatMessageService.broadcast()`와 완전히 동일한 원칙을 따릅니다.
```
@Autowired(required = false) 적용 이유:
  RedisPubSubConfig가 @ConditionalOnProperty로 조건부 로드되므로
  Redis 비활성화 환경(로컬, 테스트)에서 chatRedisTemplate 빈이 존재하지 않음.
  required = false + publish() 내부 null 체크로 안전하게 처리.
```

`publishMemberKicked()`는 `chatRoomMemberId`를 받아 내부에서 `userId`를 조회합니다.
Controller는 `chatRoomMemberId`만 알고 있고, 강퇴된 `userId`를 별도로 조회하는 것은
Publisher의 책임으로 보는 것이 더 자연스럽기 때문입니다.

**검수 포인트**

- 로컬 환경(Redis 비활성화)에서 `publishMemberJoined()` 호출 시 warn 로그만 찍히고 예외 없이 동작하는지 확인
- `publishMemberKicked()` 내에서 `chatRoomMemberRepository.findById()`로 조회 시 강퇴된 멤버의 userId가 정상적으로 반환되는지 확인 (kicked_at이 설정되어 있어도 PK 조회이므로 문제없음)

---

### 4. `SseEventSubscriber`

기존 `RedisSubscriber`와 별도 클래스로 분리했습니다.
```
RedisSubscriber      → chat-room:* 채널 → WebSocket 브로드캐스트 (채팅 메시지)
SseEventSubscriber   → chat-sse:* 채널  → SSE push (채팅방 상태 변경)
```

하나의 클래스에서 두 채널을 처리하면 단일 책임 원칙을 위반하고,
이후 어느 한쪽을 변경할 때 다른 쪽에 영향을 줄 수 있습니다.

`findAllActiveMembersByChatRoomId()`로 전체 멤버를 조회한 뒤 각각 `sendChatEvent()`를 호출합니다.
다중 서버 환경에서 각 서버는 자신에게 연결된 Emitter만 보유하므로
`sendChatEvent()` 내부에서 `emitters.get(userId)`가 null이면 조용히 스킵됩니다.
모든 서버에서 동일하게 실행되므로 결과적으로 전체 멤버에게 이벤트가 전달됩니다.

**검수 포인트**

- `ROOM_CLOSED` 이벤트 수신 시 `findAllActiveMembersByChatRoomId()`가 이미 종료된 채팅방 멤버를 정상 반환하는지 확인 (종료가 `status=CLOSED` 처리이고 멤버 레코드는 유지되므로 문제없음)
- Redis 역직렬화 시 `ChatSseEvent`로 정상 변환되는지 확인

---

### 5. `RedisPubSubConfig`

기존 컨테이너에 `chat-sse:*` 패턴 리스너를 추가합니다.

`sseMessageListenerAdapter`를 별도 빈으로 분리한 이유는 Spring이 같은 타입의 빈을 이름으로 구분하기 때문입니다.
동일한 `MessageListenerAdapter` 타입으로 두 개의 빈을 등록하므로 `@Bean` 메서드명(`messageListenerAdapter`, `sseMessageListenerAdapter`)이 곧 빈 이름이 되어 `redisMessageListenerContainer` 파라미터로 각각 주입받습니다.

**검수 포인트**

- 애플리케이션 기동 시 `chat-room:*` 와 `chat-sse:*` 두 패턴이 모두 구독되는지 로그 확인
- `messageListenerAdapter`와 `sseMessageListenerAdapter` 빈 이름 충돌이 없는지 확인

---

### 6. `ChatRoomController` — 이벤트 발행 지점

**`leaveChatRoom()` 분기 처리**

`leaveChatRoom()`은 void이므로 방장 자동 종료인지 일반 멤버 퇴장인지 Controller에서 알 수 없습니다.
반환 타입을 바꾸면 기존 Service 시그니처가 변경되고 영향 범위가 커지므로,
커밋 완료 후 `isRoomClosed()`로 상태를 한 번 더 조회하는 방식을 선택했습니다.
```java
chatRoomService.isRoomClosed(chatRoomId)
    ? sseEventPublisher.publishRoomClosed(chatRoomId)
    : sseEventPublisher.publishMemberLeft(chatRoomId);
```

DB 조회가 1회 추가되지만 채팅방 상태 조회는 PK 기반이라 비용이 낮고,
Service 인터페이스를 안정적으로 유지하는 것이 더 중요하다고 판단했습니다.

**트랜잭션 경계**

모든 publish 호출은 `@Transactional` 메서드 리턴(= 커밋 완료) 이후에 위치합니다.
커밋 전에 publish하면 클라이언트가 이벤트 수신 후 멤버 목록을 즉시 재조회할 때
DB에 아직 반영되지 않은 데이터를 받는 레이스 컨디션이 발생합니다.
`ChatMessageService.broadcast()`와 동일한 원칙입니다.

**검수 포인트**

- 방장이 나가기(`leaveChatRoom`) 시 `isRoomClosed()`가 true를 반환하고 `publishRoomClosed()`가 호출되는지 확인
- 일반 멤버가 나가기 시 `isRoomClosed()`가 false를 반환하고 `publishMemberLeft()`가 호출되는지 확인
- 입장/퇴장/강퇴/종료 각각의 SSE 이벤트가 채팅방 목록 화면에서 인원수 갱신 및 상태 변경으로 반영되는지 확인

---

## 한계 및 향후 고려사항

`leaveChatRoom()` 이후 `isRoomClosed()` 조회가 추가되는 구조는 Service 반환 타입을 `boolean`으로 변경하면 제거할 수 있습니다. 현재는 기존 인터페이스 안정성을 우선했으나 리팩터링 시 개선 가능합니다.