### PR TITLE
fix : MEMBER_KICKED 이벤트 강퇴 대상 본인에게 SSE push

### DIFF
--- a/src/main/java/com/thunder11/scuad/infra/redis/SseEventSubscriber.java
+++ b/src/main/java/com/thunder11/scuad/infra/redis/SseEventSubscriber.java
@@ -58,6 +58,18 @@ public class SseEventSubscriber implements MessageListener {
             chatRoomMemberRepository.findAllActiveMembersByChatRoomId(chatRoomId)
                     .forEach(member -> sseEmitterRegistry.sendChatEvent(member.getUserId(), event));
 
+            // MEMBER_KICKED 이벤트 시 강퇴된 본인에게도 별도 push
+            //
+            // findAllActiveMembersByChatRoomId()는 kicked_at IS NULL 조건으로 조회하므로
+            // 강퇴된 멤버는 이미 kicked_at이 설정되어 위 목록에서 제외된다.
+            // 그러나 강퇴된 본인도 채팅방 내부 화면에서 강제 이탈 처리를 받아야 하므로
+            // kickedUserId를 페이로드에서 꺼내 별도로 push한다.
+            if ("MEMBER_KICKED".equals(event.getType()) && event.getKickedUserId() != null) {
+                sseEmitterRegistry.sendChatEvent(event.getKickedUserId(), event);
+                log.info("강퇴 대상에게 SSE 이벤트 push 완료: kickedUserId={}, chatRoomId={}",
+                        event.getKickedUserId(), chatRoomId);
+            }
+
             log.info("SSE 이벤트 브로드캐스트 완료: chatRoomId={}, type={}", chatRoomId, event.getType());
 
         } catch (Exception e) {


### PR DESCRIPTION
## 개요

채팅방 내부 화면에서 헤더 인원수(`1/5명`)와 멤버 목록이 다른 참여자의 입장/퇴장/강퇴/종료 시 실시간으로 반영되지 않는 문제를 해결합니다.

서버 인프라(SSE, Redis Pub/Sub, SseEventPublisher, SseEventSubscriber)는 채팅방 목록 실시간화 PR에서 이미 구축되어 있습니다.
이번 PR의 실질적인 서버 변경은 **`SseEventSubscriber` 버그 수정 1개**입니다.

---

## 변경 파일

**기존 수정 (1개)**
- `infra/redis/SseEventSubscriber.java`

---

## 발견된 버그 및 수정 내용

### 문제

`MEMBER_KICKED` 이벤트 발생 시 강퇴된 본인이 SSE 이벤트를 수신하지 못하는 버그가 있었습니다.
```
[기존 흐름]

MEMBER_KICKED 이벤트 publish
        ↓
SseEventSubscriber.onMessage()
  → findAllActiveMembersByChatRoomId()
      조건: kicked_at IS NULL
      → 강퇴된 멤버는 이미 kicked_at 설정됨 → 목록에서 제외
      → 강퇴된 본인에게 push 불가 ❌
      → 채팅방 내부 화면에서 강제 이탈 처리 불가
```

### 왜 이렇게 수정했나

`findAllActiveMembersByChatRoomId()`의 조건 자체(`kicked_at IS NULL`)는 올바릅니다.
채팅방 내 현재 활성 멤버를 조회하는 것이 목적이므로, 강퇴된 멤버가 제외되는 것은 정상 동작입니다.

문제는 이 쿼리 결과만으로는 강퇴된 본인에게 이벤트를 전달할 수 없다는 점입니다.
쿼리 조건을 바꾸면 다른 이벤트 타입에서 불필요한 멤버까지 포함될 수 있으므로,
`MEMBER_KICKED` 이벤트에 한해 `kickedUserId`를 페이로드에서 꺼내 별도로 push하는 방식을 선택했습니다.
```java
// MEMBER_KICKED 이벤트 시 강퇴된 본인에게 별도 push
if ("MEMBER_KICKED".equals(event.getType()) && event.getKickedUserId() != null) {
    sseEmitterRegistry.sendChatEvent(event.getKickedUserId(), event);
}
```

이 방식이 가능한 이유는 `ChatSseEvent.kickedUserId`가 이미 `SseEventPublisher.publishMemberKicked()`에서
채워지고 있기 때문입니다. 페이로드 구조 변경 없이 기존 필드를 활용합니다.

**검수 포인트**

- 방장이 멤버를 강퇴했을 때 강퇴된 본인의 화면에서 `MEMBER_KICKED` 이벤트가 수신되는지 확인
- 나머지 멤버도 동일하게 `MEMBER_KICKED` 이벤트를 수신하는지 확인 (인원수 갱신, 멤버 목록 제거)
- `MEMBER_JOINED`, `MEMBER_LEFT`, `ROOM_CLOSED` 이벤트는 기존 로직대로 활성 멤버 전원에게 전달되는지 확인

---

## 클라이언트가 처리해야 할 화면별 동작

서버에서 발행하는 이벤트 구조는 채팅방 목록 실시간화 PR과 동일합니다.
채팅방 내부 화면에서 아래와 같이 처리해 주세요.

| 이벤트 타입 | 채팅방 내부 화면 처리 |
|---|---|
| `MEMBER_JOINED` | 헤더 인원수 갱신, 멤버 목록에 신규 멤버 추가 |
| `MEMBER_LEFT` | 헤더 인원수 갱신, 멤버 목록에서 해당 멤버 제거 |
| `MEMBER_KICKED` | `kickedUserId === 본인 userId`이면 강퇴 안내 후 강제 이탈. 아니면 인원수 갱신 + 멤버 목록 제거 |
| `ROOM_CLOSED` | 종료 안내 모달 표시 후 채팅방 목록으로 강제 이동 |