### PR TITLE
fix : 채팅방 1공고 1채팅방 제한 규칙 버그, 닫힌 채팅방 채팅 불가

### DIFF
--- a/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/thunder11/scuad/chat/repository/ChatRoomMemberRepository.java
@@ -16,10 +16,21 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     // 채팅방의 현재 인원 수 (강퇴되지 않은 멤버만)
     long countByChatRoomIdAndKickedAtIsNull(Long chatRoomId);
 
-    // 사용자가 특정 공고의 채팅방에 이미 참여 중인지 확인 (job_application_id로 확인)
+    // 사용자가 특정 공고의 ACTIVE 채팅방에 이미 참여 중인지 확인 (job_application_id로 확인)
+    //
+    // 수정 근거:
+    //   기존 쿼리는 kickedAt IS NULL 조건만 검사하여, 방이 CLOSED/DELETED 되어도
+    //   잔존 멤버 레코드를 반환함.
+    //   → "같은 공고 내 1개 ACTIVE 방에서만 활동" 정책을 위반: 방이 종료된 후
+    //     새 방 생성·입장 시 CHAT_ROOM_ALREADY_JOINED_OTHER 에러 발생.
+    //   → ChatRoom 테이블을 JOIN하여 status = 'ACTIVE', deletedAt IS NULL 인 방만
+    //     필터링함으로써 종료된 방의 멤버 레코드를 무시하도록 변경.
     @Query("SELECT crm FROM ChatRoomMember crm " +
+            "JOIN ChatRoom cr ON cr.chatRoomId = crm.chatRoomId " +
             "WHERE crm.jobApplicationId = :jobApplicationId " +
-            "AND crm.kickedAt IS NULL")
+            "AND crm.kickedAt IS NULL " +
+            "AND cr.status = 'ACTIVE' " +
+            "AND cr.deletedAt IS NULL")
     Optional<ChatRoomMember> findByJobApplicationIdAndNotKicked(@Param("jobApplicationId") Long jobApplicationId);
 
     // 채팅방 멤버 ID로 조회 (강퇴되지 않은 멤버만)

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java
@@ -220,9 +220,17 @@ public class ChatMessageService {
         log.info("메시지 전송 시작: chatRoomId={}, userId={}, messageType={}",
                 chatRoomId, userId, request.getMessageType());
 
-        // 1. 채팅방 존재 확인
-        chatRoomRepository.findByIdNotDeleted(chatRoomId)
+        // 1. 채팅방 존재 및 ACTIVE 상태 확인
+        // 수정 근거: findByIdNotDeleted는 deletedAt IS NULL만 체크하여 CLOSED 방도 반환함.
+        //           CLOSED 방에서 내역 조회(getMessages)는 허용하되 메시지 전송은 차단해야 하므로
+        //           sendMessage에서만 status = ACTIVE 조건을 추가로 검증.
+        com.thunder11.scuad.chat.domain.ChatRoom chatRoom = chatRoomRepository.findByIdNotDeleted(chatRoomId)
                 .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        if (chatRoom.getStatus() != com.thunder11.scuad.chat.domain.type.RoomStatus.ACTIVE) {
+            log.warn("종료된 채팅방에 메시지 전송 시도: chatRoomId={}, userId={}", chatRoomId, userId);
+            throw new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND);
+        }
 
         // 2. 멤버십 확인 (참여자만 메시지 전송 가능)
         boolean isMember = chatRoomMemberRepository

--- a/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
+++ b/src/main/java/com/thunder11/scuad/chat/service/ChatRoomService.java
@@ -594,6 +594,7 @@ public class ChatRoomService {
                             chatRoomId
                     )));
             log.info("채팅방 종료 알림 이벤트 발행 완료 (방장 자동 종료): chatRoomId={}", chatRoomId);
+
             return;
         }
 


### PR DESCRIPTION
## [Fix] 채팅방 공고 내 활성 방 1개 제한 버그 수정

### 배경 / 문제 정의

동일 공고 내에서 채팅방을 생성하거나 입장한 뒤, 방을 종료(또는 방장 퇴장)하고 나서 같은 공고 내 다른 채팅방에 입장하거나 새 채팅방을 생성하려 하면 `CHAT_ROOM_ALREADY_JOINED_OTHER` 에러가 발생하는 버그가 보고되었다.

또한 방이 종료된 이후에도 기존 참여자가 메시지를 전송할 수 있는 문제도 함께 확인되었다.

---

### 요구사항 (수정 목표)

1. 한 공고 내에서 유저는 하나의 ACTIVE 채팅방에서만 활동할 수 있다.
2. 종료된 채팅방에서는 채팅 전송이 불가능하다. 단, 기존 참여자는 채팅 내역을 조회할 수 있다.

---

### 원인 분석

#### 버그 1 — `CHAT_ROOM_ALREADY_JOINED_OTHER` 오발동

`joinChatRoom`, `getChatRoomsByJobPosting`에서 "동일 공고 내 다른 방 참여 여부"를 검증할 때 아래 쿼리를 사용한다.
```java
// AS-IS
@Query("SELECT crm FROM ChatRoomMember crm " +
        "WHERE crm.jobApplicationId = :jobApplicationId " +
        "AND crm.kickedAt IS NULL")
Optional<ChatRoomMember> findByJobApplicationIdAndNotKicked(Long jobApplicationId);
```

이 쿼리는 `kickedAt IS NULL`만 체크하고 **채팅방의 상태(ACTIVE/CLOSED)를 무시**한다.

방이 종료되어도 `chat_room_members` 레코드는 삭제되지 않고 `kicked_at = NULL` 상태로 잔존한다. 결과적으로 종료된 방의 멤버 레코드가 그대로 반환되어, 이후 같은 공고에서 새 방 생성·입장 시 `CHAT_ROOM_ALREADY_JOINED_OTHER` 에러가 오발동한다.

> 멤버 레코드를 삭제하는 방식도 검토했으나, `getMessages`의 멤버십 검증(`findByChatRoomIdAndUserIdAndKickedAtIsNull`)이 레코드 존재에 의존하기 때문에 삭제 시 종료된 방의 내역 조회가 불가능해지는 새로운 버그가 발생한다. 따라서 레코드는 보존하고 쿼리 레벨에서 ACTIVE 방만 필터링하는 방식으로 수정한다.

#### 버그 2 — 종료된 방에서 메시지 전송 가능

`sendMessage`에서 채팅방 존재 확인에 `findByIdNotDeleted`를 사용한다. 이 쿼리는 `deletedAt IS NULL`만 체크하고 `status`는 무시하므로 CLOSED 방도 통과된다. 이후 별도의 상태 검증이 없어 종료된 방에서도 메시지 전송이 허용된다.

---

### 변경 내용

#### 1. `ChatRoomMemberRepository` — `findByJobApplicationIdAndNotKicked` 쿼리 수정

`chat_rooms` 테이블을 JOIN하여 `status = 'ACTIVE'`, `deletedAt IS NULL` 조건을 추가한다. 종료된 방의 멤버 레코드를 무시하여 버그 1을 해소한다.
```java
// AS-IS
@Query("SELECT crm FROM ChatRoomMember crm " +
        "WHERE crm.jobApplicationId = :jobApplicationId " +
        "AND crm.kickedAt IS NULL")

// TO-BE
@Query("SELECT crm FROM ChatRoomMember crm " +
        "JOIN ChatRoom cr ON cr.chatRoomId = crm.chatRoomId " +
        "WHERE crm.jobApplicationId = :jobApplicationId " +
        "AND crm.kickedAt IS NULL " +
        "AND cr.status = 'ACTIVE' " +
        "AND cr.deletedAt IS NULL")
```

#### 2. `ChatMessageService` — `sendMessage`에 ACTIVE 상태 검증 추가

`findByIdNotDeleted` 조회 후 `status != ACTIVE`이면 예외를 던진다. `getMessages`(내역 조회)는 상태 검증을 추가하지 않아 CLOSED 방 조회를 허용한다.
```java
// TO-BE (sendMessage 내부)
ChatRoom chatRoom = chatRoomRepository.findByIdNotDeleted(chatRoomId)
        .orElseThrow(() -> new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND));

if (chatRoom.getStatus() != RoomStatus.ACTIVE) {
    throw new ApiException(ErrorCode.CHAT_ROOM_NOT_FOUND);
}
```

---

### 최종 동작 검증

| 시나리오 | 처리 위치 | 결과 |
|---|---|---|
| ACTIVE 방 참여 중 → 같은 공고 다른 방 입장 시도 | `findByJobApplicationIdAndNotKicked` (ACTIVE JOIN) | ❌ 차단 |
| 방 종료 후 → 같은 공고 새 방 생성·입장 | 동일 쿼리가 CLOSED 방 무시 | ✅ 허용 |
| 같은 공고 방 중복 생성 | `existsByJobMasterIdAndCreatedByAndDeletedAtIsNullAndStatus(ACTIVE)` | ❌ 차단 |
| 종료된 방 → 채팅 내역 조회 | `findByIdNotDeleted` (status 무관) + 멤버 레코드 보존 | ✅ 허용 |
| 종료된 방 → 메시지 전송 | `sendMessage` 내 `status != ACTIVE` 검증 | ❌ 차단 |

---

### 변경 파일 목록

- `src/main/java/com/thunder11/scuad/chat/repository/ChatRoomMemberRepository.java`
- `src/main/java/com/thunder11/scuad/chat/service/ChatMessageService.java`