### PR TITLE
fix : 리프레쉬 토큰 재발급 문제

### DIFF
--- a/src/main/java/com/thunder11/scuad/auth/controller/AuthController.java
+++ b/src/main/java/com/thunder11/scuad/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import com.thunder11.scuad.auth.service.AuthService;
 import com.thunder11.scuad.auth.dto.RefreshTokenRequest;
 import com.thunder11.scuad.auth.dto.TokenRefreshResponse;
 import com.thunder11.scuad.common.exception.ApiException;
+import com.thunder11.scuad.common.response.ApiResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -106,8 +107,15 @@ public class AuthController {
 
     // Access Token 재발급
     // Refresh Token을 쿠키에서 받아서 새로운 Access Token과 Refresh Token 발급
+    //
+    // 수정 근거: 기존 TokenRefreshResponse 직접 반환 시 응답 구조가
+    //   { accessToken, refreshToken, tokenType, expiresIn } 으로 래퍼 없이 반환됨.
+    //   프론트엔드는 모든 API가 ApiResponse<T> 구조({ status, code, message, data })라고
+    //   가정하고 response.data.accessToken 을 읽는데, 래퍼가 없으면 .data 가 undefined가 되어
+    //   "Cannot destructure property 'accessToken' of 't.data'" 에러 발생 후 AUTH_CLEARED 처리됨.
+    //   → 다른 컨트롤러와 동일하게 ApiResponse<TokenRefreshResponse> 로 감싸서 반환하도록 수정.
     @PostMapping("/refresh")
-    public TokenRefreshResponse refreshToken(
+    public ApiResponse<TokenRefreshResponse> refreshToken(
             @CookieValue(name = "refreshToken") String refreshToken,
             HttpServletResponse response
     ) {
@@ -129,7 +137,7 @@ public class AuthController {
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
         log.info("토큰 재발급 완료, 새 Refresh Token을 HttpOnly 쿠키로 설정");
 
-        return tokenResponse;
+        return ApiResponse.of(200, "SUCCESS", "토큰 재발급 성공", tokenResponse);
     }
 
     // 로그아웃 (전체 디바이스 무효화)


### PR DESCRIPTION
## [Fix] 액세스 토큰 만료 시 자동 재발급 실패 버그 수정

### 배경 / 문제 정의

액세스 토큰이 만료된 이후 리프레시 토큰을 통한 자동 재발급이 이루어지지 않고, 사용자에게 "로그인이 필요합니다" 알림이 뜨며 강제 로그아웃되는 버그가 보고되었다.

콘솔 에러:
```
GET /api/v1/notifications/unread-count 401 (Unauthorized)
Auth sync failed: TypeError: Cannot destructure property 'accessToken' of 't.data' as it is undefined.
Auth error event received: {type: 'AUTH_CLEARED'}
```

---

### 원인 분석

프론트엔드는 모든 API 응답이 공통 래퍼 구조를 따른다고 가정하고 `response.data.accessToken`으로 토큰을 읽는다.
```json
// 프론트가 기대하는 구조 (ApiResponse<T>)
{ "status": 200, "code": "SUCCESS", "message": "...", "data": { "accessToken": "..." } }
```

그런데 `AuthController.refreshToken`만 `TokenRefreshResponse`를 **`ApiResponse` 래퍼 없이 직접 반환**하고 있었다.
```json
// 실제 반환되던 구조
{ "accessToken": "...", "refreshToken": "...", "tokenType": "Bearer", "expiresIn": ... }
```

결과적으로 `response.data` 자체가 `undefined`가 되어 destructuring 에러 발생 → 리프레시 실패로 간주 → `AUTH_CLEARED` → 강제 로그아웃으로 이어졌다.

프론트 코드나 환경 설정 문제가 아닌, **백엔드 응답 구조 누락**이 원인이다.

---

### 변경 내용

`AuthController` — `refreshToken` 반환 타입을 `ApiResponse<TokenRefreshResponse>`로 수정
```java
// AS-IS
public TokenRefreshResponse refreshToken(...) {
    ...
    return tokenResponse;
}

// TO-BE
public ApiResponse<TokenRefreshResponse> refreshToken(...) {
    ...
    return ApiResponse.of(200, "SUCCESS", "토큰 재발급 성공", tokenResponse);
}
```

---

### 변경 전후 응답 비교

| | AS-IS | TO-BE |
|---|---|---|
| 반환 타입 | `TokenRefreshResponse` | `ApiResponse<TokenRefreshResponse>` |
| 응답 구조 | `{ accessToken, refreshToken, ... }` | `{ status, code, message, data: { accessToken, ... } }` |
| 프론트 `response.data` | `undefined` → 에러 | `{ accessToken, ... }` → 정상 |
| 결과 | `AUTH_CLEARED` → 강제 로그아웃 | 액세스 토큰 자동 재발급 후 세션 유지 |

---

### 변경 파일 목록

- `src/main/java/com/thunder11/scuad/auth/controller/AuthController.java`